### PR TITLE
Add sample data configs

### DIFF
--- a/src/configs/data/default.yaml
+++ b/src/configs/data/default.yaml
@@ -1,0 +1,34 @@
+# Default configuration for the data pipeline
+
+# Time range for data fetching
+start: 2021-01-01
+end: 2021-12-31
+timestep: day  # day, hour or minute
+
+# Coinbase perpetual futures symbols for historical data
+coinbase_perp_symbols:
+  - BTC-USD
+  - ETH-USD
+
+# OANDA FX pairs for historical data
+oanda_fx_symbols:
+  - EUR_USD
+  - GBP_USD
+
+# Synthetic data generators used for testing
+synthetic_symbols:
+  - TEST1
+  - TEST2
+
+# Symbols to fetch from live data APIs (stubbed)
+live_symbols:
+  - BTC-USD
+  - EUR_USD
+
+# Feature generation options
+generate_features: true        # Compute technical indicators
+advanced_candles: true         # Include advanced candlestick patterns
+
+# Output settings
+to_csv: true                   # Write datasets to CSV
+output_dir: data/raw           # Directory where CSV files are stored

--- a/src/configs/data/historical.yaml
+++ b/src/configs/data/historical.yaml
@@ -1,0 +1,25 @@
+# Configuration focusing on historical data retrieval
+
+# Date range for the download
+start: 2020-01-01
+end: 2020-12-31
+timestep: day
+
+# Historical markets to pull
+coinbase_perp_symbols:
+  - BTC-USD
+
+oanda_fx_symbols:
+  - EUR_USD
+
+# Optional synthetic and live sources (empty by default)
+synthetic_symbols: []
+live_symbols: []
+
+# Feature processing controls
+generate_features: false  # Skip feature generation
+advanced_candles: false   # Only basic candlestick patterns
+
+# Output configuration
+to_csv: true              # Save data to CSV files
+output_dir: data/historical  # Directory for historical CSVs


### PR DESCRIPTION
## Summary
- flesh out default and historical data configs with comments
- document output options and feature flags

## Testing
- `pytest -q` *(fails: test_detect_hammer, test_detect_inside_bar, test_detect_three_white_soldiers, test_detect_three_black_crows)*
- `pytest tests/test_data_pipeline.py tests/test_data_pipeline_edge_cases.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a64abf0c832e97438ecd2d9c6da8