### PR TITLE
Fix indentation of sentiment test cleanup

### DIFF
--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -232,7 +232,7 @@ class TestSentimentModuleError:
             # Test overwriting with correct structure
             sentiment.sentiment['TEST'] = {'score': 0.5}
             assert isinstance(sentiment.sentiment['TEST'], dict)
-              finally:
+        finally:
             # Restore original state
             sentiment.sentiment.clear()
             sentiment.sentiment.update(original_sentiment)


### PR DESCRIPTION
## Summary
- fix indentation of `finally` in `test_sentiment_dict_type_safety`

## Testing
- `pytest tests/test_sentiment.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e34a74b8832e86b0160dae2dfcf5