### PR TITLE
Fix TA-Lib build in local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ A reinforcement learning framework for algorithmic trading, providing customizab
  git clone https://github.com/yourusername/trading-rl-agent.git
 cd trading-rl-agent
 
-# Install dependencies (Ray with Tune extras included)
-pip install -r requirements.txt
+# Set up a virtual environment and install dependencies
+# (Installs C/C++ build tools for TA-Lib and may require sudo)
+./setup_env.sh
 
 # Build Docker image (CPU)
 docker build -t trading-rl-agent .

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Setup a local Python virtual environment with all project dependencies.
+
+set -e
+
+PYTHON_BIN=${PYTHON_BIN:-python3}
+VENV_DIR=".venv"
+
+# Install system build tools if using a Debian based OS
+if command -v apt-get >/dev/null; then
+    sudo apt-get update
+    sudo apt-get install -y --no-install-recommends \
+        build-essential wget autoconf automake libtool pkg-config \
+        software-properties-common cmake git python3-dev libssl-dev \
+        libgl1 libglib2.0-0
+fi
+
+# Build and install TA-Lib C library if missing
+if ! ldconfig -p | grep -q libta_lib; then
+    wget -q http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz
+    tar -xzf ta-lib-0.4.0-src.tar.gz
+    pushd ta-lib >/dev/null
+    ./configure --prefix=/usr/local
+    make
+    sudo make install
+    popd >/dev/null
+    rm -rf ta-lib ta-lib-0.4.0-src.tar.gz
+    sudo ldconfig
+fi
+
+if [ ! -d "$VENV_DIR" ]; then
+    "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+# shellcheck disable=SC1091
+source "$VENV_DIR/bin/activate"
+
+pip install --upgrade pip setuptools wheel
+
+# Install numpy first to avoid compiled wheel issues
+pip install numpy==1.23.5
+
+# Install remaining requirements including Ray with Tune extras
+pip install -r requirements.txt --ignore-installed blinker
+
+# Install the package in editable mode
+pip install -e .
+
+echo "Environment setup complete. Activate with 'source $VENV_DIR/bin/activate'."


### PR DESCRIPTION
## Summary
- ensure the setup script installs system build tools and TA‑Lib source
- note that running `setup_env.sh` may require sudo permissions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6841f34f2130832eac64983be23246c0