### PR TITLE
Update TA-Lib build paths in setup_env.sh

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -15,11 +15,24 @@ source "$VENV_DIR/bin/activate"
 
 pip install --upgrade pip setuptools wheel
 
+# Build TA-Lib C library if not already installed
+if ! ldconfig -p | grep -q libta_lib.so; then
+    wget -q http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz
+    tar -xzf ta-lib-0.4.0-src.tar.gz
+    (cd ta-lib && ./configure && make && make install)
+    rm -rf ta-lib ta-lib-0.4.0-src.tar.gz
+fi
+
+# Set library paths for TA-Lib Python wheel
+export TA_LIBRARY_PATH=/usr/local/lib
+export TA_INCLUDE_PATH=/usr/local/include
+
 # Install numpy first to avoid compiled wheel issues
 pip install numpy==1.23.5
 
 # Install remaining requirements including Ray with Tune extras
-pip install -r requirements.txt --ignore-installed blinker
+TA_LIBRARY_PATH=/usr/local/lib TA_INCLUDE_PATH=/usr/local/include \
+    pip install -r requirements.txt --ignore-installed blinker
 
 # Install the package in editable mode
 pip install -e .


### PR DESCRIPTION
## Summary
- build TA-Lib if not available when setting up the environment
- export TA_LIBRARY_PATH and TA_INCLUDE_PATH
- use these paths when installing Python requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6841fbe8fcd0832ea0e02eef2725e47f