### PR TITLE
Fix duplicated ta-lib package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # filepath: d:/trading-rl-agent/requirements.txt
 numpy
-TA-Lib
 stable-baselines3[extra]==2.1.0
 ray[tune]==2.43.0
 hydra-core==1.3.2


### PR DESCRIPTION
## Summary
- remove duplicate entry for TA-Lib in requirements

## Testing
- `pytest tests/test_empty_modules.py::TestEmptyModules::test_cnn_lstm_module_exists -q`


------
https://chatgpt.com/codex/tasks/task_e_6841fc8ee5c8832eb937105fb9067a2d