### PR TITLE
Parallelize data ingestion with Ray

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ trade-agent \
 ray stop
 ```
 
+## Data Pipeline with Ray
+
+`run_pipeline` now uses Ray to parallelize data ingestion. By default it
+connects to a local Ray instance, or you can specify a cluster address with the
+`RAY_ADDRESS` environment variable or `ray_address` field in the pipeline
+configuration. Example:
+
+```bash
+export RAY_ADDRESS="ray://head-node:10001"
+python -m src.data.pipeline --config src/configs/data/pipeline.yaml
+```
+
 ## Testing
 
 ```pwsh

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -1,6 +1,8 @@
 import pandas as pd
 import yaml
 import pytest
+import ray
+
 from src.data.pipeline import run_pipeline
 
 @pytest.fixture(autouse=True)
@@ -46,7 +48,9 @@ def test_run_pipeline(tmp_path, dummy_fetch):
     cfg_path = tmp_path / "cfg.yaml"
     cfg_path.write_text(yaml.safe_dump(cfg))
 
+    ray.init(local_mode=True, log_to_driver=False)
     results = run_pipeline(str(cfg_path))
+    ray.shutdown()
 
     # Check that all expected keys are present
     assert "coinbase_SYM" in results

--- a/tests/test_data_pipeline_edge_cases.py
+++ b/tests/test_data_pipeline_edge_cases.py
@@ -2,6 +2,7 @@
 import yaml
 import pytest
 import pandas as pd
+import ray
 from pathlib import Path
 from src.data.pipeline import run_pipeline
 
@@ -45,7 +46,9 @@ def test_no_symbols(tmp_path, dummy_fetch):
     cfg_path = tmp_path / "cfg.yaml"
     cfg_path.write_text(yaml.safe_dump(cfg))
 
+    ray.init(local_mode=True, log_to_driver=False)
     results = run_pipeline(str(cfg_path))
+    ray.shutdown()
     assert results == {}, "Expected empty results when no symbols are configured"
 
     raw_dir = Path(cfg["output_dir"])
@@ -68,7 +71,9 @@ def test_to_csv_creates_files(tmp_path, dummy_fetch):
     cfg_path = tmp_path / "cfg.yaml"
     cfg_path.write_text(yaml.safe_dump(cfg))
 
+    ray.init(local_mode=True, log_to_driver=False)
     results = run_pipeline(str(cfg_path))
+    ray.shutdown()
     key = "coinbase_ABC"
     assert key in results, f"Results should contain key '{key}'"
     assert results[key].equals(dummy_fetch), "Returned DataFrame should match dummy"


### PR DESCRIPTION
## Summary
- scale data pipeline using Ray tasks for concurrent symbol fetch
- update tests to init Ray locally for deterministic execution
- document Ray pipeline usage in README

## Testing
- `pytest tests/test_data_pipeline.py tests/test_data_pipeline_edge_cases.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'agents')*

------
https://chatgpt.com/codex/tasks/task_e_684228e19e3c832e9c82065ee30d4e39