### PR TITLE
Parallelize data ingestion with Ray

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,30 @@ trade-agent \
 ray stop
 ```
 
+## Data Pipeline with Ray
+
+`run_pipeline` now uses Ray to parallelize data ingestion. By default it
+connects to a local Ray instance, or you can specify a cluster address with the
+`RAY_ADDRESS` environment variable or `ray_address` field in the pipeline
+configuration. Example:
+
+```bash
+export RAY_ADDRESS="ray://head-node:10001"
+python -m src.data.pipeline --config src/configs/data/pipeline.yaml
+```
+
+## Trading Environment
+
+The `TradingEnv` module implements a Gym-compatible environment used for RL
+training. Configure it with paths to CSV datasets and parameters like
+`window_size`, `initial_balance` and `transaction_cost`. Example:
+
+```python
+from src.envs.trading_env import TradingEnv
+env = TradingEnv({"dataset_paths": ["data.csv"], "window_size": 10})
+obs, _ = env.reset()
+```
+
 ## Testing
 
 ```pwsh

--- a/src/agents/trainer.py
+++ b/src/agents/trainer.py
@@ -3,7 +3,7 @@ import os
 import glob
 import ray
 
-from src.envs.trader_env import register_env
+from src.envs.trading_env import register_env
 try:
     from ray.rllib.algorithms.ppo import PPOTrainer
 except ImportError:  # Ray >=2.3 renames Trainer classes

--- a/src/agents/tune.py
+++ b/src/agents/tune.py
@@ -4,7 +4,7 @@ import yaml
 import ray
 from ray import tune
 
-from src.envs.trader_env import register_env
+from src.envs.trading_env import register_env
 
 
 def _convert_value(value):

--- a/src/data/historical.py
+++ b/src/data/historical.py
@@ -1,5 +1,8 @@
 import pandas as pd
-import yfinance as yf
+try:
+    import yfinance as yf
+except ModuleNotFoundError:  # Allow import when yfinance not installed
+    yf = None
 
 # use yfinance for free historical data
 client = yf

--- a/src/data/live.py
+++ b/src/data/live.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import pandas as pd
-import yfinance as yf
+try:
+    import yfinance as yf
+except ModuleNotFoundError:  # Allow import when yfinance not installed
+    yf = None
 
 
 def fetch_live_data(symbol: str, start: str, end: str, timestep: str = "day") -> pd.DataFrame:

--- a/src/data/pipeline.py
+++ b/src/data/pipeline.py
@@ -1,12 +1,20 @@
 import os
-import yaml
 from pathlib import Path
+
 import pandas as pd
+import yaml
+import ray
 
 from .historical import fetch_historical_data
 from .features import generate_features
 from .synthetic import fetch_synthetic_data
 from .live import fetch_live_data
+
+
+@ray.remote
+def _fetch_data_remote(fetch_fn, symbol: str, start: str, end: str, timestep: str):
+    """Execute a data fetch function as a Ray remote task."""
+    return fetch_fn(symbol, start, end, timestep)
 
 
 def load_cached_csvs(directory: str) -> pd.DataFrame:
@@ -44,64 +52,72 @@ def load_cached_csvs(directory: str) -> pd.DataFrame:
 
 
 def run_pipeline(config_path: str):
-    """
-    Run data pipeline to fetch historical OHLCV data for configured symbols.
+    """Run the data ingestion pipeline using Ray for parallelism.
 
-    Returns a dict mapping symbol keys to DataFrames.
+    Parameters
+    ----------
+    config_path : str
+        Path to a YAML configuration file defining symbols and output options.
+
+    Returns
+    -------
+    dict[str, pandas.DataFrame]
+        Mapping of ``source`` keys to DataFrames containing OHLCV data.
     """
     with open(config_path) as f:
         cfg = yaml.safe_load(f)
 
-    start = cfg.get('start')
-    end = cfg.get('end')
-    timestep = cfg.get('timestep', 'day')
-    coinbase_symbols = cfg.get('coinbase_perp_symbols', [])
-    oanda_symbols = cfg.get('oanda_fx_symbols', [])
-    output_dir = cfg.get('output_dir', 'data/raw')
-    to_csv = cfg.get('to_csv', True)
+    start = cfg.get("start")
+    end = cfg.get("end")
+    timestep = cfg.get("timestep", "day")
+    coinbase_symbols = cfg.get("coinbase_perp_symbols", [])
+    oanda_symbols = cfg.get("oanda_fx_symbols", [])
+    output_dir = cfg.get("output_dir", "data/raw")
+    to_csv = cfg.get("to_csv", True)
 
     Path(output_dir).mkdir(parents=True, exist_ok=True)
-    results = {}
 
-    # Fetch Coinbase perpetual futures data
+    started_ray = False
+    if not ray.is_initialized():
+        ray.init(address=cfg.get("ray_address", os.getenv("RAY_ADDRESS")),
+                 log_to_driver=False)
+        started_ray = True
+
+    tasks = {}
+
     for symbol in coinbase_symbols:
         key = f"coinbase_{symbol}"
-        df = fetch_historical_data(symbol, start, end, timestep)
-        results[key] = df
-        if to_csv:
-            csv_path = Path(output_dir) / f"{key}.csv"
-            df.to_csv(csv_path)
+        tasks[key] = _fetch_data_remote.remote(fetch_historical_data, symbol, start, end, timestep)
 
-    # Fetch OANDA FX data
     for symbol in oanda_symbols:
         key = f"oanda_{symbol}"
-        df = fetch_historical_data(symbol, start, end, timestep)
-        results[key] = df
-        if to_csv:
-            csv_path = Path(output_dir) / f"{key}.csv"
-            df.to_csv(csv_path)
+        tasks[key] = _fetch_data_remote.remote(fetch_historical_data, symbol, start, end, timestep)
 
-    # Generate Synthetic data sources
-    for symbol in cfg.get('synthetic_symbols', []):
+    for symbol in cfg.get("synthetic_symbols", []):
         key = f"synthetic_{symbol}"
-        df = fetch_synthetic_data(symbol, start, end, timestep)
-        # Only apply feature generation to OHLCV-style data
-        if 'close' in df.columns:
+        tasks[key] = _fetch_data_remote.remote(fetch_synthetic_data, symbol, start, end, timestep)
+
+    for symbol in cfg.get("live_symbols", []):
+        key = f"live_{symbol}"
+        tasks[key] = _fetch_data_remote.remote(fetch_live_data, symbol, start, end, timestep)
+
+    fetched = ray.get(list(tasks.values())) if tasks else []
+
+    results = {}
+    for key, df in zip(tasks.keys(), fetched):
+        if key.startswith("synthetic_"):
+            if "close" in df.columns:
+                df = generate_features(df)
+        if key.startswith("live_"):
             df = generate_features(df)
+
         results[key] = df
         if to_csv:
             csv_path = Path(output_dir) / f"{key}.csv"
             df.to_csv(csv_path)
 
-    # Fetch Live data sources
-    for symbol in cfg.get('live_symbols', []):
-        key = f"live_{symbol}"
-        df = fetch_live_data(symbol, start, end, timestep)
-        df = generate_features(df)
-        results[key] = df
-        if to_csv:
-            csv_path = Path(output_dir) / f"{key}.csv"
-            df.to_csv(csv_path)
+    if started_ray:
+        ray.shutdown()
 
     return results
 

--- a/src/envs/trading_env.py
+++ b/src/envs/trading_env.py
@@ -1,26 +1,36 @@
-import gymnasium as gym
+"""Custom trading environment using Gym interface compatible with RLlib."""
+
+from __future__ import annotations
+
 import numpy as np
 import pandas as pd
+import gymnasium as gym
+from pathlib import Path
 
-class TraderEnv(gym.Env):
-    """Simple trading environment for demonstration purposes."""
+from src.data.features import generate_features
+
+
+class TradingEnv(gym.Env):
+    """A simple trading environment with configurable parameters."""
 
     metadata = {"render.modes": ["human"]}
 
-    def __init__(self, data_paths, initial_balance=10000, window_size=50, transaction_cost=0.001):
-        super().__init__()
-        if isinstance(data_paths, str):
-            data_paths = [data_paths]
-        self.data_paths = data_paths
-        self.initial_balance = initial_balance
-        self.window_size = window_size
-        self.transaction_cost = transaction_cost
+    def __init__(self, env_cfg: dict):
+        cfg = env_cfg or {}
+        self.data_paths = cfg.get("dataset_paths", [])
+        if isinstance(self.data_paths, str):
+            self.data_paths = [self.data_paths]
+
+        self.window_size = int(cfg.get("window_size", 50))
+        self.initial_balance = float(cfg.get("initial_balance", 1_0000))
+        self.transaction_cost = float(cfg.get("transaction_cost", 0.001))
+        self.include_features = bool(cfg.get("include_features", False))
 
         self.data = self._load_data()
         if len(self.data) <= self.window_size:
             raise ValueError("Not enough data for the specified window_size")
 
-        self.action_space = gym.spaces.Discrete(3)  # 0 hold, 1 buy, 2 sell
+        self.action_space = gym.spaces.Discrete(3)  # hold/buy/sell
         obs_shape = (self.window_size, self.data.shape[1])
         self.observation_space = gym.spaces.Box(
             low=-np.inf, high=np.inf, shape=obs_shape, dtype=np.float32
@@ -30,18 +40,17 @@ class TraderEnv(gym.Env):
 
     # ------------------------------------------------------------------
     def _load_data(self) -> pd.DataFrame:
-        dfs = []
+        frames = []
         for path in self.data_paths:
             df = pd.read_csv(path)
-            dfs.append(df)
-        data = pd.concat(dfs, ignore_index=True)
-        # ensure float32 for observations
+            frames.append(df)
+        data = pd.concat(frames, ignore_index=True)
+        if self.include_features:
+            data = generate_features(data)
         return data.astype(np.float32)
 
-    def _get_observation(self):
-        obs = self.data.iloc[
-            self.current_step - self.window_size : self.current_step
-        ].values
+    def _get_observation(self) -> np.ndarray:
+        obs = self.data.iloc[self.current_step - self.window_size : self.current_step].values
         return obs.astype(np.float32)
 
     # Gym API -----------------------------------------------------------
@@ -49,15 +58,13 @@ class TraderEnv(gym.Env):
         super().reset(seed=seed)
         self.current_step = self.window_size
         self.balance = float(self.initial_balance)
-        self.position = 0  # -1 short, 0 flat, 1 long
-        obs = self._get_observation()
-        return obs, {}
+        self.position = 0
+        return self._get_observation(), {}
 
-    def step(self, action):
+    def step(self, action: int):
         assert self.action_space.contains(action), "Invalid action"
         prev_price = self.data.loc[self.current_step - 1, "close"]
 
-        # Update position with transaction cost when changing
         new_position = {0: self.position, 1: 1, 2: -1}[action]
         cost = 0.0
         if new_position != self.position:
@@ -67,9 +74,10 @@ class TraderEnv(gym.Env):
         self.current_step += 1
         done = self.current_step >= len(self.data)
         current_price = self.data.loc[self.current_step - 1, "close"]
-        price_diff = current_price - prev_price
+        price_diff = float(current_price - prev_price)
         reward = float(self.position * price_diff - cost)
         self.balance += reward
+
         obs = self._get_observation() if not done else np.zeros_like(self.observation_space.sample())
         info = {"balance": self.balance}
         return obs, reward, done, False, info
@@ -80,18 +88,14 @@ class TraderEnv(gym.Env):
             f"Position: {self.position}, Balance: {self.balance}"
         )
 
-# Registration -------------------------------------------------------------
+
+# Registration helpers ---------------------------------------------------------
 
 def env_creator(env_cfg):
-    data_paths = env_cfg.get("dataset_paths", [])
-    return TraderEnv(
-        data_paths,
-        initial_balance=env_cfg.get("initial_balance", 10000),
-        window_size=env_cfg.get("window_size", 50),
-        transaction_cost=env_cfg.get("transaction_cost", 0.001),
-    )
+    return TradingEnv(env_cfg)
 
 
-def register_env():
+def register_env(name: str = "TradingEnv"):
     from ray.tune.registry import register_env as ray_register_env
-    ray_register_env("TraderEnv", env_creator)
+
+    ray_register_env(name, lambda cfg: TradingEnv(cfg))

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -1,6 +1,8 @@
 import pandas as pd
 import yaml
 import pytest
+import ray
+
 from src.data.pipeline import run_pipeline
 
 @pytest.fixture(autouse=True)
@@ -46,7 +48,9 @@ def test_run_pipeline(tmp_path, dummy_fetch):
     cfg_path = tmp_path / "cfg.yaml"
     cfg_path.write_text(yaml.safe_dump(cfg))
 
+    ray.init(local_mode=True, log_to_driver=False)
     results = run_pipeline(str(cfg_path))
+    ray.shutdown()
 
     # Check that all expected keys are present
     assert "coinbase_SYM" in results

--- a/tests/test_data_pipeline_edge_cases.py
+++ b/tests/test_data_pipeline_edge_cases.py
@@ -2,6 +2,7 @@
 import yaml
 import pytest
 import pandas as pd
+import ray
 from pathlib import Path
 from src.data.pipeline import run_pipeline
 
@@ -45,7 +46,9 @@ def test_no_symbols(tmp_path, dummy_fetch):
     cfg_path = tmp_path / "cfg.yaml"
     cfg_path.write_text(yaml.safe_dump(cfg))
 
+    ray.init(local_mode=True, log_to_driver=False)
     results = run_pipeline(str(cfg_path))
+    ray.shutdown()
     assert results == {}, "Expected empty results when no symbols are configured"
 
     raw_dir = Path(cfg["output_dir"])
@@ -68,7 +71,9 @@ def test_to_csv_creates_files(tmp_path, dummy_fetch):
     cfg_path = tmp_path / "cfg.yaml"
     cfg_path.write_text(yaml.safe_dump(cfg))
 
+    ray.init(local_mode=True, log_to_driver=False)
     results = run_pipeline(str(cfg_path))
+    ray.shutdown()
     key = "coinbase_ABC"
     assert key in results, f"Results should contain key '{key}'"
     assert results[key].equals(dummy_fetch), "Returned DataFrame should match dummy"

--- a/tests/test_ray_integration.py
+++ b/tests/test_ray_integration.py
@@ -10,7 +10,7 @@ sys.modules["gym"] = gym
 import ray
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.tune.registry import register_env
-from src.envs.trader_env import env_creator
+from src.envs.trading_env import env_creator
 
 class FlattenWrapper(gym.ObservationWrapper):
     """Flatten observations so RLlib can handle 2D arrays."""

--- a/tests/test_trading_env.py
+++ b/tests/test_trading_env.py
@@ -1,0 +1,59 @@
+import pandas as pd
+import numpy as np
+import gymnasium as gym
+import pytest
+
+from src.envs.trading_env import TradingEnv, env_creator, register_env
+
+
+@pytest.fixture
+def sample_csv(tmp_path):
+    data = pd.DataFrame({
+        "open": [1.0] * 60,
+        "high": [1.0] * 60,
+        "low": [1.0] * 60,
+        "close": np.linspace(1.0, 2.0, 60),
+        "volume": [1.0] * 60,
+    })
+    csv = tmp_path / "data.csv"
+    data.to_csv(csv, index=False)
+    return str(csv)
+
+
+@pytest.fixture
+def env(sample_csv):
+    cfg = {"dataset_paths": [sample_csv], "window_size": 10}
+    return TradingEnv(cfg)
+
+
+def test_reset_returns_observation(env):
+    obs, info = env.reset()
+    assert obs.shape == (10, env.data.shape[1])
+    assert env.current_step == env.window_size
+    assert info == {}
+
+
+def test_step_changes_balance(env):
+    env.reset()
+    _, reward, _, _, info = env.step(1)
+    assert isinstance(reward, float)
+    assert isinstance(info, dict)
+    assert info["balance"] == env.balance
+
+
+def test_env_creator(sample_csv):
+    cfg = {"dataset_paths": [sample_csv], "window_size": 5}
+    env = env_creator(cfg)
+    assert isinstance(env, TradingEnv)
+    assert env.window_size == 5
+
+
+def test_register_env(sample_csv):
+    cfg = {"dataset_paths": [sample_csv], "window_size": 5}
+    try:
+        register_env()
+    except Exception:
+        # registration may fail if ray not initialized
+        pass
+    env = env_creator(cfg)
+    assert env.action_space.n == 3


### PR DESCRIPTION
## Summary
- scale data pipeline using Ray tasks for concurrent symbol fetch
- lazily import optional yfinance dependency
- upgrade TraderEnv and add new TradingEnv environment module
- register TradingEnv in Trainer and Tune workflows
- document environment usage in README

## Testing
- `pytest tests/test_data_pipeline.py tests/test_data_pipeline_edge_cases.py tests/test_trader_env.py tests/test_trading_env.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684228e19e3c832e9c82065ee30d4e39