### PR TITLE
Add data ingestion/feature pipeline

### DIFF
--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -1,0 +1,210 @@
+"""Data ingestion and feature engineering pipeline for trading data.
+
+This module provides utilities to load historical market data from different
+sources, compute common technical indicators, and split the resulting dataset
+into train/validation/test segments.  It is designed to be configuration driven
+and easily extended.  Example usage:
+
+>>> from src.data_pipeline import PipelineConfig, load_data, generate_features, split_by_date
+>>> cfg = PipelineConfig(sma_windows=[3], momentum_windows=[3], rsi_window=14, vol_window=5)
+>>> df = load_data({"type": "csv", "path": "prices.csv"})
+>>> features = generate_features(df, cfg)
+>>> train, val, test = split_by_date(features, '2020-01-01', '2020-06-01')
+
+The functions rely primarily on pandas for computations but can scale to larger
+than memory datasets by leveraging Ray Datasets when ``use_ray`` is set in the
+configuration.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, Any, List, Tuple
+
+import numpy as np
+import pandas as pd
+
+try:
+    import ray.data as rdata
+except Exception:  # pragma: no cover - Ray is optional
+    rdata = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PipelineConfig:
+    """Configuration for feature generation."""
+
+    sma_windows: List[int] = field(default_factory=lambda: [5, 10])
+    momentum_windows: List[int] = field(default_factory=list)
+    rsi_window: int = 14
+    vol_window: int = 20
+    use_ray: bool = False
+
+
+def load_data(source_cfg: Dict[str, Any]) -> pd.DataFrame:
+    """Load market data from a CSV file or database.
+
+    Parameters
+    ----------
+    source_cfg : dict
+        Configuration with at least a ``type`` key. Supported types are
+        ``"csv"`` and ``"database"``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame containing the historical data with a ``timestamp`` column.
+    """
+    src_type = source_cfg.get("type", "csv")
+    logger.info("Loading data of type %s", src_type)
+
+    if src_type == "csv":
+        path = source_cfg["path"]
+        df = pd.read_csv(path, parse_dates=["timestamp"])
+        logger.info("Loaded %d rows from %s", len(df), path)
+        return df
+    elif src_type == "database":
+        import sqlite3  # lightweight default
+
+        conn = sqlite3.connect(source_cfg["connection"])
+        query = source_cfg.get("query", "SELECT * FROM prices")
+        df = pd.read_sql_query(query, conn, parse_dates=["timestamp"])
+        conn.close()
+        logger.info("Loaded %d rows from database", len(df))
+        return df
+
+    raise ValueError(f"Unsupported data source type: {src_type}")
+
+
+# ---------------------------------------------------------------------------
+# Feature computations
+# ---------------------------------------------------------------------------
+
+def compute_log_returns(df: pd.DataFrame) -> pd.DataFrame:
+    """Add log returns column ``log_return``.
+
+    log_return_t = log(close_t / close_{t-1})
+    """
+    df = df.copy()
+    df["log_return"] = np.log(df["close"] / df["close"].shift(1))
+    return df
+
+
+def compute_sma(df: pd.DataFrame, window: int) -> pd.DataFrame:
+    """Add simple moving average feature.
+
+    SMA_t = mean(close_{t-window+1:t})
+    """
+    df = df.copy()
+    df[f"sma_{window}"] = df["close"].rolling(window).mean()
+    return df
+
+
+def compute_momentum(df: pd.DataFrame, window: int) -> pd.DataFrame:
+    """Add momentum indicator as difference from ``window`` days ago."""
+    df = df.copy()
+    df[f"mom_{window}"] = df["close"].diff(window)
+    return df
+
+
+def compute_rsi(df: pd.DataFrame, window: int) -> pd.DataFrame:
+    """Add Relative Strength Index (RSI) feature."""
+    df = df.copy()
+    delta = df["close"].diff()
+    up = delta.clip(lower=0)
+    down = -delta.clip(upper=0)
+    roll_up = up.rolling(window=window).mean()
+    roll_down = down.rolling(window=window).mean()
+    rs = roll_up / roll_down
+    df[f"rsi_{window}"] = 100 - (100 / (1 + rs))
+    return df
+
+
+def compute_volatility(df: pd.DataFrame, window: int) -> pd.DataFrame:
+    """Add rolling volatility based on ``log_return``."""
+    df = df.copy()
+    df[f"vol_{window}"] = df["log_return"].rolling(window).std(ddof=0) * np.sqrt(window)
+    return df
+
+
+# ---------------------------------------------------------------------------
+
+
+def generate_features(df: pd.DataFrame, cfg: PipelineConfig) -> pd.DataFrame:
+    """Generate features as specified in ``cfg``.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Input OHLCV data sorted by ``timestamp``.
+    cfg : PipelineConfig
+        Configuration specifying which indicators to compute.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with feature columns appended.
+    """
+    if cfg.use_ray and rdata is not None:
+        logger.info("Using Ray Datasets for feature computation")
+        ds = rdata.from_pandas(df)
+        for w in cfg.sma_windows:
+            ds = ds.map_batches(lambda d, w=w: compute_sma(d, w))
+        for w in cfg.momentum_windows:
+            ds = ds.map_batches(lambda d, w=w: compute_momentum(d, w))
+        ds = ds.map_batches(lambda d: compute_log_returns(d))
+        ds = ds.map_batches(lambda d: compute_rsi(d, cfg.rsi_window))
+        ds = ds.map_batches(lambda d: compute_volatility(d, cfg.vol_window))
+        df = ds.to_pandas()
+    else:
+        df = df.copy()
+        df = compute_log_returns(df)
+        for w in cfg.sma_windows:
+            df = compute_sma(df, w)
+        for w in cfg.momentum_windows:
+            df = compute_momentum(df, w)
+        df = compute_rsi(df, cfg.rsi_window)
+        df = compute_volatility(df, cfg.vol_window)
+
+    return df
+
+
+def split_by_date(
+    df: pd.DataFrame, train_end: str, val_end: str
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Split dataframe into train/validation/test by date.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Input dataframe with a ``timestamp`` column.
+    train_end : str
+        Last date (exclusive) for the training set.
+    val_end : str
+        Last date (exclusive) for the validation set. The remainder is test.
+
+    Returns
+    -------
+    tuple of DataFrames
+        ``(train_df, val_df, test_df)`` split chronologically.
+    """
+    df = df.sort_values("timestamp")
+    train_end_ts = pd.to_datetime(train_end)
+    val_end_ts = pd.to_datetime(val_end)
+
+    train = df[df["timestamp"] < train_end_ts]
+    val = df[(df["timestamp"] >= train_end_ts) & (df["timestamp"] < val_end_ts)]
+    test = df[df["timestamp"] >= val_end_ts]
+
+    return train.reset_index(drop=True), val.reset_index(drop=True), test.reset_index(drop=True)
+
+
+__all__ = [
+    "PipelineConfig",
+    "load_data",
+    "generate_features",
+    "split_by_date",
+]

--- a/src/supervised_model.py
+++ b/src/supervised_model.py
@@ -1,0 +1,216 @@
+"""Supervised learning model and training utilities for trend prediction.
+
+This module implements ``TrendPredictor`` - a CNN + LSTM architecture used to
+predict market trends from sequences of engineered features.  A simple training
+routine ``train_supervised`` is provided which can train the model on numpy or
+pandas inputs and optionally runs on GPU.  Example usage:
+
+>>> from src.supervised_model import ModelConfig, TrainingConfig, train_supervised
+>>> features, targets = load_some_data()
+>>> model_cfg = ModelConfig(task='classification')
+>>> train_cfg = TrainingConfig(epochs=5)
+>>> model, history = train_supervised(features, targets, model_cfg, train_cfg)
+
+The training function returns the model and a history dictionary of losses and
+metrics.  Hyperparameters are configurable via ``ModelConfig`` and
+``TrainingConfig`` and can easily be extended for Ray Tune hyperparameter
+search (see the ``tune_example`` function at the bottom of this file).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Iterable, Tuple, Dict, List, Any
+
+import numpy as np
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+logger = logging.getLogger(__name__)
+
+
+def _to_tensor(data: Any) -> torch.Tensor:
+    """Convert numpy array or pandas DataFrame to float tensor."""
+    if hasattr(data, "values"):
+        data = data.values
+    return torch.as_tensor(data, dtype=torch.float32)
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for :class:`TrendPredictor`."""
+
+    cnn_filters: Iterable[int] = field(default_factory=lambda: [16, 32])
+    cnn_kernel_sizes: Iterable[int] = field(default_factory=lambda: [3, 3])
+    lstm_units: int = 32
+    dropout: float = 0.1
+    output_size: int = 1
+    task: str = "classification"  # or 'regression'
+
+
+@dataclass
+class TrainingConfig:
+    """Configuration for ``train_supervised``."""
+
+    learning_rate: float = 1e-3
+    batch_size: int = 32
+    epochs: int = 10
+    val_split: float = 0.2
+
+
+class TrendPredictor(nn.Module):
+    """CNN + LSTM model for trend prediction."""
+
+    def __init__(self, input_dim: int, config: ModelConfig | None = None):
+        super().__init__()
+        cfg = config or ModelConfig()
+        self.task = cfg.task
+        filters = list(cfg.cnn_filters)
+        kernels = list(cfg.cnn_kernel_sizes)
+        if len(filters) != len(kernels):
+            raise ValueError("cnn_filters and cnn_kernel_sizes must have same length")
+
+        layers: List[nn.Module] = []
+        in_ch = input_dim
+        for out_ch, k in zip(filters, kernels):
+            layers.append(nn.Conv1d(in_ch, out_ch, kernel_size=k))
+            layers.append(nn.ReLU())
+            in_ch = out_ch
+        self.conv = nn.Sequential(*layers)
+        self.lstm = nn.LSTM(input_size=in_ch, hidden_size=cfg.lstm_units, batch_first=True)
+        self.dropout = nn.Dropout(cfg.dropout)
+        self.fc = nn.Linear(cfg.lstm_units, cfg.output_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : Tensor
+            Shape ``(batch, seq_len, features)``.
+        """
+        x = x.transpose(1, 2)  # -> (batch, channels, seq)
+        x = self.conv(x)
+        x = x.transpose(1, 2)  # -> (batch, seq, channels)
+        out, _ = self.lstm(x)
+        out = out[:, -1, :]
+        out = self.dropout(out)
+        out = self.fc(out)
+        if self.task == "classification":
+            out = torch.sigmoid(out)
+        return out
+
+
+def _split_data(x: torch.Tensor, y: torch.Tensor, val_split: float) -> Tuple[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor]]:
+    """Split tensors into train and validation sets chronologically."""
+    n = x.shape[0]
+    split = int(n * (1 - val_split))
+    return (x[:split], y[:split]), (x[split:], y[split:])
+
+
+def train_supervised(
+    features: Any,
+    targets: Any,
+    model_cfg: ModelConfig | None = None,
+    train_cfg: TrainingConfig | None = None,
+) -> Tuple[TrendPredictor, Dict[str, List[float]]]:
+    """Train ``TrendPredictor`` on provided data.
+
+    Parameters
+    ----------
+    features : array-like
+        Input data of shape ``(samples, seq_len, features)``.
+    targets : array-like
+        Target values of shape ``(samples, output_size)`` or ``(samples,)``.
+    model_cfg : ModelConfig, optional
+        Configuration for the model.
+    train_cfg : TrainingConfig, optional
+        Training hyperparameters.
+
+    Returns
+    -------
+    model : TrendPredictor
+        The trained model.
+    history : dict
+        Dictionary with lists of ``train_loss`` and ``val_loss`` (and ``val_acc`` if classification).
+    """
+    m_cfg = model_cfg or ModelConfig()
+    t_cfg = train_cfg or TrainingConfig()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    logger.info("Using device %s", device)
+
+    x = _to_tensor(features)
+    y = _to_tensor(targets).reshape(len(features), -1)
+
+    (x_train, y_train), (x_val, y_val) = _split_data(x, y, t_cfg.val_split)
+
+    train_ds = TensorDataset(x_train, y_train)
+    val_ds = TensorDataset(x_val, y_val)
+
+    train_loader = DataLoader(train_ds, batch_size=t_cfg.batch_size, shuffle=False)
+    val_loader = DataLoader(val_ds, batch_size=t_cfg.batch_size)
+
+    model = TrendPredictor(input_dim=x.shape[2], config=m_cfg).to(device)
+
+    if m_cfg.task == "classification":
+        criterion = nn.BCELoss()
+    else:
+        criterion = nn.MSELoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=t_cfg.learning_rate)
+
+    history = {"train_loss": [], "val_loss": [], "val_acc": []}
+    for epoch in range(t_cfg.epochs):
+        model.train()
+        total_loss = 0.0
+        for xb, yb in train_loader:
+            xb, yb = xb.to(device), yb.to(device)
+            optimizer.zero_grad()
+            pred = model(xb)
+            loss = criterion(pred, yb)
+            loss.backward()
+            optimizer.step()
+            total_loss += loss.item() * xb.size(0)
+        avg_loss = total_loss / len(train_loader.dataset)
+        history["train_loss"].append(avg_loss)
+
+        model.eval()
+        val_loss = 0.0
+        correct = 0
+        count = 0
+        with torch.no_grad():
+            for xb, yb in val_loader:
+                xb, yb = xb.to(device), yb.to(device)
+                pred = model(xb)
+                val_loss += criterion(pred, yb).item() * xb.size(0)
+                if m_cfg.task == "classification":
+                    predicted = (pred > 0.5).float()
+                    correct += (predicted == yb).all(dim=1).sum().item()
+                    count += xb.size(0)
+        val_loss /= max(1, len(val_loader.dataset))
+        history["val_loss"].append(val_loss)
+        if m_cfg.task == "classification":
+            acc = correct / max(1, count)
+            history["val_acc"].append(acc)
+            logger.info("Epoch %d: train_loss=%.4f val_loss=%.4f val_acc=%.3f", epoch + 1, avg_loss, val_loss, acc)
+        else:
+            logger.info("Epoch %d: train_loss=%.4f val_loss=%.4f", epoch + 1, avg_loss, val_loss)
+
+    return model, history
+
+
+def tune_example():
+    """Illustrative example of wrapping training for Ray Tune."""
+
+    # from ray import tune
+    # def train_fn(config):
+    #     model_cfg = ModelConfig(**config.get("model", {}))
+    #     train_cfg = TrainingConfig(**config.get("train", {}))
+    #     _, history = train_supervised(features, targets, model_cfg, train_cfg)
+    #     tune.report(loss=history["val_loss"][-1])
+    pass
+
+
+__all__ = ["TrendPredictor", "ModelConfig", "TrainingConfig", "train_supervised"]

--- a/tests/test_data_ingestion_pipeline.py
+++ b/tests/test_data_ingestion_pipeline.py
@@ -1,0 +1,53 @@
+import pandas as pd
+import numpy as np
+import pytest
+
+from src.data_pipeline import PipelineConfig, generate_features, split_by_date
+
+
+def test_sma_computation():
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2021-01-01", periods=5, freq="D"),
+        "open": np.arange(5),
+        "high": np.arange(5),
+        "low": np.arange(5),
+        "close": [1, 2, 3, 4, 5],
+        "volume": 1
+    })
+    cfg = PipelineConfig(sma_windows=[3], momentum_windows=[], rsi_window=2, vol_window=2)
+    result = generate_features(df, cfg)
+    expected = [np.nan, np.nan, 2.0, 3.0, 4.0]
+    assert np.allclose(result["sma_3"].values, expected, equal_nan=True)
+
+
+def test_split_by_date_no_overlap():
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2021-01-01", periods=7, freq="D"),
+        "close": np.arange(7)
+    })
+    train, val, test = split_by_date(df, "2021-01-03", "2021-01-06")
+    assert len(train) == 2
+    assert len(val) == 3
+    assert len(test) == 2
+    # ensure no overlap
+    all_dates = pd.concat([train, val, test])["timestamp"]
+    assert all_dates.is_unique
+    assert all_dates.is_monotonic_increasing
+
+
+def test_generate_features_with_missing_values():
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2021-01-01", periods=3, freq="D"),
+        "open": [1.0, 2.0, 3.0],
+        "high": [1.0, 2.0, 3.0],
+        "low": [1.0, 2.0, 3.0],
+        "close": [1.0, np.nan, 3.0],
+        "volume": 1
+    })
+    cfg = PipelineConfig(sma_windows=[2], momentum_windows=[1], rsi_window=2, vol_window=2)
+    result = generate_features(df, cfg)
+    # Should keep same number of rows
+    assert len(result) == 3
+    # SMA should have NaN where insufficient data
+    assert result["sma_2"].isnull().sum() >= 1
+

--- a/tests/test_supervised_model.py
+++ b/tests/test_supervised_model.py
@@ -1,0 +1,30 @@
+import numpy as np
+import torch
+
+from src.supervised_model import TrendPredictor, ModelConfig, TrainingConfig, train_supervised
+
+
+def test_model_output_shape():
+    cfg = ModelConfig(cnn_filters=[4], cnn_kernel_sizes=[2], lstm_units=8)
+    model = TrendPredictor(input_dim=3, config=cfg)
+    x = torch.randn(2, 5, 3)
+    out = model(x)
+    assert out.shape == (2, 1)
+
+
+def test_training_step_reduces_loss():
+    x = np.random.randn(20, 4, 1).astype(np.float32)
+    y = x.sum(axis=1)
+    model_cfg = ModelConfig(task="regression", cnn_filters=[2], cnn_kernel_sizes=[2], lstm_units=4)
+    train_cfg = TrainingConfig(epochs=3, batch_size=5, learning_rate=0.01, val_split=0.2)
+    _, history = train_supervised(x, y, model_cfg, train_cfg)
+    assert history["train_loss"][0] > history["train_loss"][-1]
+
+
+def test_validation_accuracy_perfect_when_same_data():
+    x = np.random.randn(10, 3, 1).astype(np.float32)
+    y = (x.sum(axis=1) > 0).astype(np.float32)
+    model_cfg = ModelConfig(task="classification", cnn_filters=[2], cnn_kernel_sizes=[2], lstm_units=4)
+    train_cfg = TrainingConfig(epochs=2, batch_size=2, val_split=0.5)
+    _, history = train_supervised(x, y, model_cfg, train_cfg)
+    assert 0.0 <= history["val_acc"][-1] <= 1.0


### PR DESCRIPTION
## Summary
- implement new `data_pipeline.py` with config-driven feature generation, data loading and train/val/test split
- add pytest tests for moving average, splitting and missing value handling
- add CNN+LSTM `TrendPredictor` with training routine for supervised trend prediction
- add tests for model shapes and training logic

## Testing
- `pytest -q tests/test_supervised_model.py`
- `pytest -q` *(fails: ModuleNotFoundError for pandas, yaml, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68423bd4cf34832e97b0ed13ad84ffb4