### PR TITLE
Add data ingestion/feature pipeline

### DIFF
--- a/ray_cluster_setup.yaml
+++ b/ray_cluster_setup.yaml
@@ -1,0 +1,14 @@
+# Example Ray cluster configuration for the trading RL agent
+# Adjust addresses/resources to match the Proxmox setup.
+head_address: "ray://gpu-head:10001"
+workers:
+  - address: "ray://cpu-worker1:10001"
+    resources:
+      CPU: 4
+  - address: "ray://cpu-worker2:10001"
+    resources:
+      CPU: 4
+  - address: "ray://gpu-worker:10001"
+    resources:
+      CPU: 16
+      GPU: 1

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -1,0 +1,210 @@
+"""Data ingestion and feature engineering pipeline for trading data.
+
+This module provides utilities to load historical market data from different
+sources, compute common technical indicators, and split the resulting dataset
+into train/validation/test segments.  It is designed to be configuration driven
+and easily extended.  Example usage:
+
+>>> from src.data_pipeline import PipelineConfig, load_data, generate_features, split_by_date
+>>> cfg = PipelineConfig(sma_windows=[3], momentum_windows=[3], rsi_window=14, vol_window=5)
+>>> df = load_data({"type": "csv", "path": "prices.csv"})
+>>> features = generate_features(df, cfg)
+>>> train, val, test = split_by_date(features, '2020-01-01', '2020-06-01')
+
+The functions rely primarily on pandas for computations but can scale to larger
+than memory datasets by leveraging Ray Datasets when ``use_ray`` is set in the
+configuration.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, Any, List, Tuple
+
+import numpy as np
+import pandas as pd
+
+try:
+    import ray.data as rdata
+except Exception:  # pragma: no cover - Ray is optional
+    rdata = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PipelineConfig:
+    """Configuration for feature generation."""
+
+    sma_windows: List[int] = field(default_factory=lambda: [5, 10])
+    momentum_windows: List[int] = field(default_factory=list)
+    rsi_window: int = 14
+    vol_window: int = 20
+    use_ray: bool = False
+
+
+def load_data(source_cfg: Dict[str, Any]) -> pd.DataFrame:
+    """Load market data from a CSV file or database.
+
+    Parameters
+    ----------
+    source_cfg : dict
+        Configuration with at least a ``type`` key. Supported types are
+        ``"csv"`` and ``"database"``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame containing the historical data with a ``timestamp`` column.
+    """
+    src_type = source_cfg.get("type", "csv")
+    logger.info("Loading data of type %s", src_type)
+
+    if src_type == "csv":
+        path = source_cfg["path"]
+        df = pd.read_csv(path, parse_dates=["timestamp"])
+        logger.info("Loaded %d rows from %s", len(df), path)
+        return df
+    elif src_type == "database":
+        import sqlite3  # lightweight default
+
+        conn = sqlite3.connect(source_cfg["connection"])
+        query = source_cfg.get("query", "SELECT * FROM prices")
+        df = pd.read_sql_query(query, conn, parse_dates=["timestamp"])
+        conn.close()
+        logger.info("Loaded %d rows from database", len(df))
+        return df
+
+    raise ValueError(f"Unsupported data source type: {src_type}")
+
+
+# ---------------------------------------------------------------------------
+# Feature computations
+# ---------------------------------------------------------------------------
+
+def compute_log_returns(df: pd.DataFrame) -> pd.DataFrame:
+    """Add log returns column ``log_return``.
+
+    log_return_t = log(close_t / close_{t-1})
+    """
+    df = df.copy()
+    df["log_return"] = np.log(df["close"] / df["close"].shift(1))
+    return df
+
+
+def compute_sma(df: pd.DataFrame, window: int) -> pd.DataFrame:
+    """Add simple moving average feature.
+
+    SMA_t = mean(close_{t-window+1:t})
+    """
+    df = df.copy()
+    df[f"sma_{window}"] = df["close"].rolling(window).mean()
+    return df
+
+
+def compute_momentum(df: pd.DataFrame, window: int) -> pd.DataFrame:
+    """Add momentum indicator as difference from ``window`` days ago."""
+    df = df.copy()
+    df[f"mom_{window}"] = df["close"].diff(window)
+    return df
+
+
+def compute_rsi(df: pd.DataFrame, window: int) -> pd.DataFrame:
+    """Add Relative Strength Index (RSI) feature."""
+    df = df.copy()
+    delta = df["close"].diff()
+    up = delta.clip(lower=0)
+    down = -delta.clip(upper=0)
+    roll_up = up.rolling(window=window).mean()
+    roll_down = down.rolling(window=window).mean()
+    rs = roll_up / roll_down
+    df[f"rsi_{window}"] = 100 - (100 / (1 + rs))
+    return df
+
+
+def compute_volatility(df: pd.DataFrame, window: int) -> pd.DataFrame:
+    """Add rolling volatility based on ``log_return``."""
+    df = df.copy()
+    df[f"vol_{window}"] = df["log_return"].rolling(window).std(ddof=0) * np.sqrt(window)
+    return df
+
+
+# ---------------------------------------------------------------------------
+
+
+def generate_features(df: pd.DataFrame, cfg: PipelineConfig) -> pd.DataFrame:
+    """Generate features as specified in ``cfg``.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Input OHLCV data sorted by ``timestamp``.
+    cfg : PipelineConfig
+        Configuration specifying which indicators to compute.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with feature columns appended.
+    """
+    if cfg.use_ray and rdata is not None:
+        logger.info("Using Ray Datasets for feature computation")
+        ds = rdata.from_pandas(df)
+        for w in cfg.sma_windows:
+            ds = ds.map_batches(lambda d, w=w: compute_sma(d, w))
+        for w in cfg.momentum_windows:
+            ds = ds.map_batches(lambda d, w=w: compute_momentum(d, w))
+        ds = ds.map_batches(lambda d: compute_log_returns(d))
+        ds = ds.map_batches(lambda d: compute_rsi(d, cfg.rsi_window))
+        ds = ds.map_batches(lambda d: compute_volatility(d, cfg.vol_window))
+        df = ds.to_pandas()
+    else:
+        df = df.copy()
+        df = compute_log_returns(df)
+        for w in cfg.sma_windows:
+            df = compute_sma(df, w)
+        for w in cfg.momentum_windows:
+            df = compute_momentum(df, w)
+        df = compute_rsi(df, cfg.rsi_window)
+        df = compute_volatility(df, cfg.vol_window)
+
+    return df
+
+
+def split_by_date(
+    df: pd.DataFrame, train_end: str, val_end: str
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Split dataframe into train/validation/test by date.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Input dataframe with a ``timestamp`` column.
+    train_end : str
+        Last date (exclusive) for the training set.
+    val_end : str
+        Last date (exclusive) for the validation set. The remainder is test.
+
+    Returns
+    -------
+    tuple of DataFrames
+        ``(train_df, val_df, test_df)`` split chronologically.
+    """
+    df = df.sort_values("timestamp")
+    train_end_ts = pd.to_datetime(train_end)
+    val_end_ts = pd.to_datetime(val_end)
+
+    train = df[df["timestamp"] < train_end_ts]
+    val = df[(df["timestamp"] >= train_end_ts) & (df["timestamp"] < val_end_ts)]
+    test = df[df["timestamp"] >= val_end_ts]
+
+    return train.reset_index(drop=True), val.reset_index(drop=True), test.reset_index(drop=True)
+
+
+__all__ = [
+    "PipelineConfig",
+    "load_data",
+    "generate_features",
+    "split_by_date",
+]

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,1 +1,2 @@
 from .cnn_lstm import CNNLSTMModel
+from .concat_model import ConcatModel

--- a/src/models/concat_model.py
+++ b/src/models/concat_model.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import numpy as np
+import torch
+from torch import nn
+from ray.rllib.models.torch.torch_modelv2 import TorchModelV2
+from ray.rllib.utils.torch_ops import FLOAT_MIN
+from ray.rllib.models import ModelCatalog
+
+
+class ConcatModel(TorchModelV2, nn.Module):
+    """Simple model that processes market features and model prediction separately
+    then concatenates them before the policy and value heads."""
+
+    def __init__(self, obs_space, action_space, num_outputs, model_config, name):
+        TorchModelV2.__init__(self, obs_space, action_space, num_outputs, model_config, name)
+        nn.Module.__init__(self)
+
+        market_shape = int(np.prod(obs_space["market_features"].shape))
+        pred_shape = int(np.prod(obs_space["model_pred"].shape))
+
+        self.market_net = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(market_shape, 64),
+            nn.ReLU(),
+        )
+        self.pred_net = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(pred_shape, 16),
+            nn.ReLU(),
+        )
+
+        hidden = 64 + 16
+        self.policy = nn.Sequential(
+            nn.Linear(hidden, 64),
+            nn.ReLU(),
+            nn.Linear(64, num_outputs),
+        )
+        self.value_branch = nn.Sequential(
+            nn.Linear(hidden, 64),
+            nn.ReLU(),
+            nn.Linear(64, 1),
+        )
+        self._features = None
+
+    def forward(self, input_dict, state, seq_lens):
+        market = self.market_net(input_dict["obs"]["market_features"])
+        pred = self.pred_net(input_dict["obs"]["model_pred"])
+        features = torch.cat([market, pred], dim=1)
+        self._features = features
+        logits = self.policy(features)
+        return logits, state
+
+    def value_function(self):
+        assert self._features is not None, "must call forward first"
+        value = self.value_branch(self._features)
+        return torch.reshape(value, [-1])
+
+
+__all__ = ["ConcatModel", "ModelCatalog"]

--- a/src/serve_deployment.py
+++ b/src/serve_deployment.py
@@ -1,0 +1,119 @@
+"""Ray Serve deployment stubs for predictor and policy models.
+
+This module defines basic `PredictorDeployment` and `PolicyDeployment` classes
+using Ray Serve. They illustrate how the trained supervised model and RL policy
+could be exposed as independent services and composed together. The logic is
+simplified so the code can run without heavy dependencies, but the structure is
+ready for future production use.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+import numpy as np
+
+try:
+    from ray import serve
+except Exception:  # pragma: no cover - ray might not be installed
+    serve = None  # type: ignore
+
+from src.supervised_model import load_model, predict_features
+
+
+if serve:
+
+    @serve.deployment
+    class PredictorDeployment:
+        """Load a trained ``TrendPredictor`` and return predictions."""
+
+        def __init__(self, model_path: Optional[str] = None):
+            self.model_path = model_path
+            self.model = None
+            if model_path:
+                try:
+                    self.model = load_model(model_path)
+                except Exception:
+                    self.model = None
+
+        async def __call__(self, request: Any) -> dict:
+            if isinstance(request, dict):
+                payload = request
+            else:  # assume HTTP request
+                payload = await request.json()
+            features = np.asarray(payload.get("features", []), dtype=np.float32)
+            if self.model is not None:
+                pred = predict_features(self.model, features).cpu().numpy()
+                pred = pred.tolist()
+            else:
+                pred = float(features.mean()) if features.size > 0 else 0.0
+            return {"prediction": pred}
+
+
+    @serve.deployment
+    class PolicyDeployment:
+        """RL policy that optionally queries ``PredictorDeployment``."""
+
+        def __init__(self, predictor_handle: Optional[Any] = None):
+            self.predictor = predictor_handle
+            self.action_space = 3  # hold/buy/sell
+
+        async def __call__(self, request: Any) -> dict:
+            if isinstance(request, dict):
+                payload = request
+            else:
+                payload = await request.json()
+            obs = np.asarray(payload.get("observation", []), dtype=np.float32)
+            pred = 0.0
+            if self.predictor is not None:
+                res = await self.predictor.__call__({"features": obs.tolist()})
+                pred = float(res.get("prediction", 0.0))
+            # Dummy policy: buy if mean(obs)+pred > 0
+            action = 1 if (obs.mean() + pred) > 0 else 0
+            return {"action": int(action)}
+
+
+    def deployment_graph(model_path: Optional[str] = None):
+        """Return a Serve deployment graph for the predictor and policy."""
+        predictor = PredictorDeployment.bind(model_path)
+        policy = PolicyDeployment.bind(predictor)
+        return {"predictor": predictor, "policy": policy}
+
+else:  # pragma: no cover - serve not available
+
+    class PredictorDeployment:  # type: ignore
+        """Fallback predictor when Ray Serve is unavailable."""
+
+        def __init__(self, model_path: Optional[str] = None):
+            self.model_path = model_path
+            self.model = load_model(model_path) if model_path else None
+
+        async def __call__(self, request: Any) -> dict:
+            features = np.asarray(request.get("features", []), dtype=np.float32)
+            pred = (
+                predict_features(self.model, features).cpu().numpy().tolist()
+                if self.model is not None
+                else float(features.mean()) if features.size > 0 else 0.0
+            )
+            return {"prediction": pred}
+
+    class PolicyDeployment:  # type: ignore
+        """Fallback policy implementation."""
+
+        def __init__(self, predictor_handle: Optional[Any] = None):
+            self.predictor = predictor_handle
+
+        async def __call__(self, request: Any) -> dict:
+            obs = np.asarray(request.get("observation", []), dtype=np.float32)
+            pred = 0.0
+            if self.predictor is not None:
+                res = await self.predictor.__call__({"features": obs.tolist()})
+                pred = float(res.get("prediction", 0.0))
+            action = 1 if (obs.mean() + pred) > 0 else 0
+            return {"action": int(action)}
+
+    def deployment_graph(model_path: Optional[str] = None):
+        predictor = PredictorDeployment(model_path)
+        policy = PolicyDeployment(predictor)
+        return {"predictor": predictor, "policy": policy}
+
+__all__ = ["PredictorDeployment", "PolicyDeployment", "deployment_graph"]

--- a/src/supervised_model.py
+++ b/src/supervised_model.py
@@ -1,0 +1,336 @@
+"""Supervised learning model and training utilities for trend prediction.
+
+This module implements ``TrendPredictor`` - a CNN + LSTM architecture used to
+predict market trends from sequences of engineered features.  A simple training
+routine ``train_supervised`` is provided which can train the model on numpy or
+pandas inputs and optionally runs on GPU.  Example usage:
+
+>>> from src.supervised_model import ModelConfig, TrainingConfig, train_supervised
+>>> features, targets = load_some_data()
+>>> model_cfg = ModelConfig(task='classification')
+>>> train_cfg = TrainingConfig(epochs=5)
+>>> model, history = train_supervised(features, targets, model_cfg, train_cfg)
+
+The training function returns the model and a history dictionary of losses and
+metrics.  Hyperparameters are configurable via ``ModelConfig`` and
+``TrainingConfig`` and can easily be extended for Ray Tune hyperparameter
+search (see the ``tune_example`` function at the bottom of this file).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Iterable, Tuple, Dict, List, Any
+
+import numpy as np
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+logger = logging.getLogger(__name__)
+
+
+def _to_tensor(data: Any) -> torch.Tensor:
+    """Convert numpy array or pandas DataFrame to float tensor."""
+    if hasattr(data, "values"):
+        data = data.values
+    return torch.as_tensor(data, dtype=torch.float32)
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for :class:`TrendPredictor`."""
+
+    cnn_filters: Iterable[int] = field(default_factory=lambda: [16, 32])
+    cnn_kernel_sizes: Iterable[int] = field(default_factory=lambda: [3, 3])
+    lstm_units: int = 32
+    dropout: float = 0.1
+    output_size: int = 1
+    task: str = "classification"  # or 'regression'
+
+
+@dataclass
+class TrainingConfig:
+    """Configuration for ``train_supervised``."""
+
+    learning_rate: float = 1e-3
+    batch_size: int = 32
+    epochs: int = 10
+    val_split: float = 0.2
+
+
+class TrendPredictor(nn.Module):
+    """CNN + LSTM model for trend prediction."""
+
+    def __init__(self, input_dim: int, config: ModelConfig | None = None):
+        super().__init__()
+        cfg = config or ModelConfig()
+        self.task = cfg.task
+        self.config = cfg
+        self.input_dim = input_dim
+        filters = list(cfg.cnn_filters)
+        kernels = list(cfg.cnn_kernel_sizes)
+        if len(filters) != len(kernels):
+            raise ValueError("cnn_filters and cnn_kernel_sizes must have same length")
+
+        layers: List[nn.Module] = []
+        in_ch = input_dim
+        for out_ch, k in zip(filters, kernels):
+            layers.append(nn.Conv1d(in_ch, out_ch, kernel_size=k))
+            layers.append(nn.ReLU())
+            in_ch = out_ch
+        self.conv = nn.Sequential(*layers)
+        self.lstm = nn.LSTM(input_size=in_ch, hidden_size=cfg.lstm_units, batch_first=True)
+        self.dropout = nn.Dropout(cfg.dropout)
+        self.fc = nn.Linear(cfg.lstm_units, cfg.output_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : Tensor
+            Shape ``(batch, seq_len, features)``.
+        """
+        x = x.transpose(1, 2)  # -> (batch, channels, seq)
+        x = self.conv(x)
+        x = x.transpose(1, 2)  # -> (batch, seq, channels)
+        out, _ = self.lstm(x)
+        out = out[:, -1, :]
+        out = self.dropout(out)
+        out = self.fc(out)
+        if self.task == "classification":
+            out = torch.sigmoid(out)
+        return out
+
+
+def _split_data(x: torch.Tensor, y: torch.Tensor, val_split: float) -> Tuple[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor]]:
+    """Split tensors into train and validation sets chronologically."""
+    n = x.shape[0]
+    split = int(n * (1 - val_split))
+    return (x[:split], y[:split]), (x[split:], y[split:])
+
+
+import ray
+
+
+@ray.remote(num_gpus=1, num_cpus=4)
+def train_supervised(
+    features: Any,
+    targets: Any,
+    model_cfg: ModelConfig | None = None,
+    train_cfg: TrainingConfig | None = None,
+) -> Tuple[TrendPredictor, Dict[str, List[float]]]:
+    """Train ``TrendPredictor`` on provided data.
+
+    Parameters
+    ----------
+    features : array-like
+        Input data of shape ``(samples, seq_len, features)``.
+    targets : array-like
+        Target values of shape ``(samples, output_size)`` or ``(samples,)``.
+    model_cfg : ModelConfig, optional
+        Configuration for the model.
+    train_cfg : TrainingConfig, optional
+        Training hyperparameters.
+
+    Returns
+    -------
+    model : TrendPredictor
+        The trained model.
+    history : dict
+        Dictionary with lists of ``train_loss`` and ``val_loss`` (and ``val_acc`` if classification).
+    """
+    m_cfg = model_cfg or ModelConfig()
+    t_cfg = train_cfg or TrainingConfig()
+
+    gpu_ids = ray.get_gpu_ids()
+    if gpu_ids:
+        device = torch.device(f"cuda:{int(gpu_ids[0])}")
+    else:
+        device = torch.device("cpu")
+    logger.info("Using device %s", device)
+
+    x = _to_tensor(features)
+    y = _to_tensor(targets).reshape(len(features), -1)
+
+    (x_train, y_train), (x_val, y_val) = _split_data(x, y, t_cfg.val_split)
+
+    train_ds = TensorDataset(x_train, y_train)
+    val_ds = TensorDataset(x_val, y_val)
+
+    train_loader = DataLoader(train_ds, batch_size=t_cfg.batch_size, shuffle=False)
+    val_loader = DataLoader(val_ds, batch_size=t_cfg.batch_size)
+
+    model = TrendPredictor(input_dim=x.shape[2], config=m_cfg).to(device)
+
+    if m_cfg.task == "classification":
+        criterion = nn.BCELoss()
+    else:
+        criterion = nn.MSELoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=t_cfg.learning_rate)
+
+    history = {"train_loss": [], "val_loss": [], "val_acc": []}
+    for epoch in range(t_cfg.epochs):
+        model.train()
+        total_loss = 0.0
+        for xb, yb in train_loader:
+            xb, yb = xb.to(device), yb.to(device)
+            optimizer.zero_grad()
+            pred = model(xb)
+            loss = criterion(pred, yb)
+            loss.backward()
+            optimizer.step()
+            total_loss += loss.item() * xb.size(0)
+        avg_loss = total_loss / len(train_loader.dataset)
+        history["train_loss"].append(avg_loss)
+
+        model.eval()
+        val_loss = 0.0
+        correct = 0
+        count = 0
+        with torch.no_grad():
+            for xb, yb in val_loader:
+                xb, yb = xb.to(device), yb.to(device)
+                pred = model(xb)
+                val_loss += criterion(pred, yb).item() * xb.size(0)
+                if m_cfg.task == "classification":
+                    predicted = (pred > 0.5).float()
+                    correct += (predicted == yb).all(dim=1).sum().item()
+                    count += xb.size(0)
+        val_loss /= max(1, len(val_loader.dataset))
+        history["val_loss"].append(val_loss)
+        if m_cfg.task == "classification":
+            acc = correct / max(1, count)
+            history["val_acc"].append(acc)
+            logger.info("Epoch %d: train_loss=%.4f val_loss=%.4f val_acc=%.3f", epoch + 1, avg_loss, val_loss, acc)
+        else:
+            logger.info("Epoch %d: train_loss=%.4f val_loss=%.4f", epoch + 1, avg_loss, val_loss)
+
+    return model, history
+
+
+def tune_example():
+    """Illustrative example of wrapping training for Ray Tune."""
+
+    # from ray import tune
+    # def train_fn(config):
+    #     model_cfg = ModelConfig(**config.get("model", {}))
+    #     train_cfg = TrainingConfig(**config.get("train", {}))
+    #     _, history = train_supervised(features, targets, model_cfg, train_cfg)
+    #     tune.report(loss=history["val_loss"][-1])
+    pass
+
+
+def save_model(model: TrendPredictor, path: str) -> None:
+    """Save ``model`` to ``path`` using :func:`torch.save`."""
+    torch.save(
+        {
+            "state_dict": model.state_dict(),
+            "config": model.config.__dict__,
+            "input_dim": model.input_dim,
+        },
+        path,
+    )
+
+
+def load_model(path: str, device: str | torch.device | None = None) -> TrendPredictor:
+    """Load a :class:`TrendPredictor` from ``path``."""
+    device = torch.device(device or "cpu")
+    checkpoint = torch.load(path, map_location=device)
+    cfg = ModelConfig(**checkpoint["config"])
+    model = TrendPredictor(checkpoint["input_dim"], cfg).to(device)
+    model.load_state_dict(checkpoint["state_dict"])
+    return model
+
+
+def evaluate_model(
+    model_or_path: TrendPredictor | str,
+    features: Any,
+    targets: Any,
+) -> Dict[str, float]:
+    """Evaluate a trained model on ``features`` and ``targets``."""
+    if isinstance(model_or_path, (str, bytes)):
+        model = load_model(model_or_path)
+    else:
+        model = model_or_path
+
+    device = next(model.parameters()).device
+    x = _to_tensor(features).to(device)
+    y = _to_tensor(targets).reshape(len(features), -1).to(device)
+
+    model.eval()
+    with torch.no_grad():
+        pred = model(x)
+
+    if model.task == "classification":
+        predicted = (pred > 0.5).float()
+        correct = (predicted == y).all(dim=1).float().mean().item()
+        tp = ((predicted == 1) & (y == 1)).sum().item()
+        fp = ((predicted == 1) & (y == 0)).sum().item()
+        fn = ((predicted == 0) & (y == 1)).sum().item()
+        precision = tp / (tp + fp + 1e-8)
+        recall = tp / (tp + fn + 1e-8)
+        return {"accuracy": correct, "precision": precision, "recall": recall}
+    else:
+        mse = torch.mean((pred - y) ** 2).item()
+        mae = torch.mean(torch.abs(pred - y)).item()
+        return {"mse": mse, "mae": mae}
+
+
+def predict_features(
+    model_or_path: TrendPredictor | str,
+    recent_data: Any,
+    device: str | torch.device | None = None,
+) -> torch.Tensor:
+    """Return model prediction for ``recent_data``."""
+    if isinstance(model_or_path, (str, bytes)):
+        model = load_model(model_or_path, device)
+    else:
+        model = model_or_path
+        if device is not None:
+            model = model.to(device)
+    device = next(model.parameters()).device
+    x = _to_tensor(recent_data)
+    if x.ndim == 2:
+        x = x.unsqueeze(0)
+    model.eval()
+    with torch.no_grad():
+        out = model(x.to(device))
+    return out.squeeze().cpu()
+
+
+def select_best_model(log_dir: str) -> str:
+    """Return path to the best model checkpoint inside ``log_dir``."""
+    import json
+    import os
+
+    best_path = ""
+    best_loss = float("inf")
+    for root, _, files in os.walk(log_dir):
+        if "metrics.json" in files:
+            mpath = os.path.join(root, "metrics.json")
+            with open(mpath) as f:
+                metrics = json.load(f)
+            loss = metrics.get("val_loss")
+            if loss is not None and loss < best_loss:
+                best_loss = loss
+                ck_rel = metrics.get("checkpoint", "model.pt")
+                best_path = os.path.join(root, ck_rel)
+    if not best_path:
+        raise FileNotFoundError("No metrics.json found in log_dir")
+    return best_path
+
+
+__all__ = [
+    "TrendPredictor",
+    "ModelConfig",
+    "TrainingConfig",
+    "train_supervised",
+    "save_model",
+    "load_model",
+    "evaluate_model",
+    "predict_features",
+    "select_best_model",
+]

--- a/src/train_rl.py
+++ b/src/train_rl.py
@@ -1,0 +1,77 @@
+"""Example RLlib training script using the TradingEnv with model predictions."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from ray.rllib.algorithms.ppo import PPOConfig
+from ray.rllib.models import ModelCatalog
+from ray.tune.registry import register_env
+
+from src.utils.cluster import init_ray, get_available_devices
+
+from src.envs.trading_env import TradingEnv
+from src.models.concat_model import ConcatModel
+
+
+def create_env(cfg):
+    return TradingEnv(cfg)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data", type=str, required=True, help="CSV file with market data")
+    parser.add_argument("--model-path", type=str, required=True, help="Path to supervised model checkpoint")
+    parser.add_argument("--num-workers", type=int, default=0)
+    parser.add_argument("--num-gpus", type=int, default=0)
+    parser.add_argument(
+        "--cluster-config",
+        type=str,
+        help="Path to ray cluster yaml config (optional)",
+    )
+    parser.add_argument(
+        "--local-mode",
+        action="store_true",
+        help="Run Ray in local mode for debugging",
+    )
+    args = parser.parse_args()
+
+    init_ray(config_path=args.cluster_config, local_mode=args.local_mode)
+    resources = get_available_devices()
+    if args.num_workers == 0:
+        # use all CPUs minus one for the driver
+        args.num_workers = max(1, int(resources["CPU"] - 1))
+    if args.num_gpus == 0 and resources.get("GPU", 0) > 0:
+        args.num_gpus = int(resources["GPU"])
+
+    env_config = {
+        "dataset_paths": [args.data],
+        "window_size": 50,
+        "model_path": args.model_path,
+    }
+
+    register_env("TradingEnvRL", lambda cfg: create_env(cfg))
+    ModelCatalog.register_custom_model("concat_model", ConcatModel)
+
+    config = (
+        PPOConfig()
+        .environment("TradingEnvRL", env_config=env_config)
+        .framework("torch")
+        .rollouts(num_rollout_workers=args.num_workers)
+        .resources(num_gpus=args.num_gpus)
+        .training(model={"custom_model": "concat_model"})
+    )
+
+    algo = config.build()
+    for _ in range(5):
+        result = algo.train()
+        print("iteration", result["training_iteration"], "reward", result["episode_reward_mean"]) 
+
+    checkpoint_dir = Path("./rl_checkpoints")
+    checkpoint_dir.mkdir(exist_ok=True)
+    algo.save(str(checkpoint_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/utils/cluster.py
+++ b/src/utils/cluster.py
@@ -1,0 +1,43 @@
+import os
+from typing import Dict
+
+import ray
+import yaml
+
+
+def init_ray(address: str | None = None, config_path: str | None = None, local_mode: bool = False):
+    """Initialize Ray with the given address or configuration.
+
+    Parameters
+    ----------
+    address : str, optional
+        Address of the Ray head node. If None, uses the ``RAY_ADDRESS``
+        environment variable or the address from ``config_path`` if provided.
+    config_path : str, optional
+        YAML file containing ``head_address``.
+    local_mode : bool, default False
+        Whether to run Ray in local mode for easier debugging.
+    """
+    if address is None:
+        address = os.getenv("RAY_ADDRESS")
+    if config_path and not address:
+        with open(config_path) as f:
+            cfg = yaml.safe_load(f)
+        address = cfg.get("head_address")
+
+    if address:
+        ray.init(address=address)
+    else:
+        ray.init(local_mode=local_mode)
+
+
+def get_available_devices() -> Dict[str, float]:
+    """Return available cluster resources (CPUs and GPUs)."""
+    if ray.is_initialized():
+        resources = ray.cluster_resources()
+    else:
+        resources = ray.available_resources()
+    return {
+        "CPU": resources.get("CPU", 0.0),
+        "GPU": resources.get("GPU", 0.0),
+    }

--- a/tests/test_cluster_utils.py
+++ b/tests/test_cluster_utils.py
@@ -1,0 +1,15 @@
+import ray
+import types
+
+from src.utils.cluster import init_ray, get_available_devices
+
+
+def test_get_available_devices(monkeypatch):
+    fake_resources = {"CPU": 8.0, "GPU": 2.0}
+
+    def fake_available():
+        return fake_resources
+
+    monkeypatch.setattr(ray, "available_resources", fake_available)
+    devices = get_available_devices()
+    assert devices == {"CPU": 8.0, "GPU": 2.0}

--- a/tests/test_concat_model.py
+++ b/tests/test_concat_model.py
@@ -1,0 +1,22 @@
+import numpy as np
+import torch
+from gymnasium import spaces
+
+from src.models.concat_model import ConcatModel
+
+
+def test_concat_model_output_shape():
+    obs_space = spaces.Dict({
+        "market_features": spaces.Box(-1.0, 1.0, shape=(5, 3)),
+        "model_pred": spaces.Box(-1.0, 1.0, shape=(1,)),
+    })
+    action_space = spaces.Discrete(2)
+    model = ConcatModel(obs_space, action_space, num_outputs=action_space.n, model_config={}, name="concat")
+    sample = {
+        "market_features": torch.zeros(1, 5, 3),
+        "model_pred": torch.zeros(1, 1),
+    }
+    logits, _ = model(sample, [], None)
+    assert logits.shape == (1, 2)
+    value = model.value_function()
+    assert value.shape == (1,)

--- a/tests/test_data_ingestion_pipeline.py
+++ b/tests/test_data_ingestion_pipeline.py
@@ -1,0 +1,53 @@
+import pandas as pd
+import numpy as np
+import pytest
+
+from src.data_pipeline import PipelineConfig, generate_features, split_by_date
+
+
+def test_sma_computation():
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2021-01-01", periods=5, freq="D"),
+        "open": np.arange(5),
+        "high": np.arange(5),
+        "low": np.arange(5),
+        "close": [1, 2, 3, 4, 5],
+        "volume": 1
+    })
+    cfg = PipelineConfig(sma_windows=[3], momentum_windows=[], rsi_window=2, vol_window=2)
+    result = generate_features(df, cfg)
+    expected = [np.nan, np.nan, 2.0, 3.0, 4.0]
+    assert np.allclose(result["sma_3"].values, expected, equal_nan=True)
+
+
+def test_split_by_date_no_overlap():
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2021-01-01", periods=7, freq="D"),
+        "close": np.arange(7)
+    })
+    train, val, test = split_by_date(df, "2021-01-03", "2021-01-06")
+    assert len(train) == 2
+    assert len(val) == 3
+    assert len(test) == 2
+    # ensure no overlap
+    all_dates = pd.concat([train, val, test])["timestamp"]
+    assert all_dates.is_unique
+    assert all_dates.is_monotonic_increasing
+
+
+def test_generate_features_with_missing_values():
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2021-01-01", periods=3, freq="D"),
+        "open": [1.0, 2.0, 3.0],
+        "high": [1.0, 2.0, 3.0],
+        "low": [1.0, 2.0, 3.0],
+        "close": [1.0, np.nan, 3.0],
+        "volume": 1
+    })
+    cfg = PipelineConfig(sma_windows=[2], momentum_windows=[1], rsi_window=2, vol_window=2)
+    result = generate_features(df, cfg)
+    # Should keep same number of rows
+    assert len(result) == 3
+    # SMA should have NaN where insufficient data
+    assert result["sma_2"].isnull().sum() >= 1
+

--- a/tests/test_serve_deployment.py
+++ b/tests/test_serve_deployment.py
@@ -1,0 +1,21 @@
+import asyncio
+
+from src.serve_deployment import PredictorDeployment, PolicyDeployment
+
+
+def test_predictor_returns_value():
+    predictor = PredictorDeployment()
+    result = asyncio.get_event_loop().run_until_complete(
+        predictor({"features": [1.0, 2.0, 3.0]})
+    )
+    assert "prediction" in result
+
+
+def test_policy_returns_action():
+    predictor = PredictorDeployment()
+    policy = PolicyDeployment(predictor)
+    result = asyncio.get_event_loop().run_until_complete(
+        policy({"observation": [0.1, -0.2]})
+    )
+    assert "action" in result
+    assert result["action"] in (0, 1)

--- a/tests/test_supervised_model.py
+++ b/tests/test_supervised_model.py
@@ -1,0 +1,86 @@
+import numpy as np
+import torch
+import pytest
+
+from src.supervised_model import (
+    TrendPredictor,
+    ModelConfig,
+    TrainingConfig,
+    train_supervised,
+    save_model,
+    load_model,
+    evaluate_model,
+    predict_features,
+    select_best_model,
+)
+
+
+def test_model_output_shape():
+    cfg = ModelConfig(cnn_filters=[4], cnn_kernel_sizes=[2], lstm_units=8)
+    model = TrendPredictor(input_dim=3, config=cfg)
+    x = torch.randn(2, 5, 3)
+    out = model(x)
+    assert out.shape == (2, 1)
+
+
+def test_training_step_reduces_loss():
+    x = np.random.randn(20, 4, 1).astype(np.float32)
+    y = x.sum(axis=1)
+    model_cfg = ModelConfig(task="regression", cnn_filters=[2], cnn_kernel_sizes=[2], lstm_units=4)
+    train_cfg = TrainingConfig(epochs=3, batch_size=5, learning_rate=0.01, val_split=0.2)
+    _, history = train_supervised(x, y, model_cfg, train_cfg)
+    assert history["train_loss"][0] > history["train_loss"][-1]
+
+
+def test_validation_accuracy_perfect_when_same_data():
+    x = np.random.randn(10, 3, 1).astype(np.float32)
+    y = (x.sum(axis=1) > 0).astype(np.float32)
+    model_cfg = ModelConfig(task="classification", cnn_filters=[2], cnn_kernel_sizes=[2], lstm_units=4)
+    train_cfg = TrainingConfig(epochs=2, batch_size=2, val_split=0.5)
+    _, history = train_supervised(x, y, model_cfg, train_cfg)
+    assert 0.0 <= history["val_acc"][-1] <= 1.0
+
+
+def test_save_and_load_consistency(tmp_path):
+    cfg = ModelConfig(cnn_filters=[2], cnn_kernel_sizes=[2], lstm_units=4)
+    model = TrendPredictor(input_dim=1, config=cfg)
+    x = torch.randn(3, 4, 1)
+    out1 = model(x)
+    path = tmp_path / "model.pt"
+    save_model(model, path)
+    loaded = load_model(path)
+    out2 = loaded(x)
+    assert torch.allclose(out1, out2)
+
+
+def test_predict_features_dummy():
+    cfg = ModelConfig(cnn_filters=[1], cnn_kernel_sizes=[1], lstm_units=1)
+    model = TrendPredictor(input_dim=2, config=cfg)
+    for p in model.parameters():
+        torch.nn.init.constant_(p, 0.0)
+    data = torch.randn(5, 2)
+    pred = predict_features(model, data)
+    assert pred.item() == pytest.approx(0.5)
+
+
+def test_evaluate_model_returns_metrics():
+    x = np.random.randn(6, 3, 1).astype(np.float32)
+    y = (x.sum(axis=1) > 0).astype(np.float32)
+    model_cfg = ModelConfig(task="classification", cnn_filters=[1], cnn_kernel_sizes=[1], lstm_units=2)
+    train_cfg = TrainingConfig(epochs=1, batch_size=2, val_split=0.0)
+    model, _ = train_supervised(x, y, model_cfg, train_cfg)
+    metrics = evaluate_model(model, x, y)
+    assert "accuracy" in metrics
+
+
+def test_select_best_model(tmp_path):
+    trial1 = tmp_path / "trial1"
+    trial1.mkdir()
+    (trial1 / "metrics.json").write_text('{"val_loss": 0.5, "checkpoint": "m.pt"}')
+    (trial1 / "m.pt").write_text("dummy")
+    trial2 = tmp_path / "trial2"
+    trial2.mkdir()
+    (trial2 / "metrics.json").write_text('{"val_loss": 0.2, "checkpoint": "m.pt"}')
+    (trial2 / "m.pt").write_text("dummy")
+    best = select_best_model(tmp_path)
+    assert "trial2" in str(best)

--- a/tests/test_trading_env_model_integration.py
+++ b/tests/test_trading_env_model_integration.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from src.envs.trading_env import TradingEnv
+from src.supervised_model import TrendPredictor, ModelConfig, save_model
+
+
+@pytest.fixture
+def dummy_model(tmp_path):
+    cfg = ModelConfig(cnn_filters=[1], cnn_kernel_sizes=[1], lstm_units=1)
+    model = TrendPredictor(input_dim=2, config=cfg)
+    for p in model.parameters():
+        torch.nn.init.constant_(p, 0.0)
+    path = tmp_path / "model.pt"
+    save_model(model, path)
+    return str(path)
+
+
+@pytest.fixture
+def sample_csv(tmp_path):
+    df = pd.DataFrame({
+        "open": np.linspace(1, 2, 60),
+        "high": np.linspace(1, 2, 60),
+        "low": np.linspace(1, 2, 60),
+        "close": np.linspace(1, 2, 60),
+        "volume": np.ones(60),
+    })
+    path = tmp_path / "data.csv"
+    df.to_csv(path, index=False)
+    return str(path)
+
+
+def test_reset_includes_model_pred(sample_csv, dummy_model):
+    env = TradingEnv({"dataset_paths": [sample_csv], "window_size": 5, "model_path": dummy_model})
+    obs, _ = env.reset()
+    assert "model_pred" in obs
+    assert obs["model_pred"].shape == (1,)
+
+
+def test_step_includes_model_pred(sample_csv, dummy_model):
+    env = TradingEnv({"dataset_paths": [sample_csv], "window_size": 5, "model_path": dummy_model})
+    env.reset()
+    obs, _, _, _, _ = env.step(0)
+    assert "model_pred" in obs
+    assert obs["model_pred"].shape == (1,)


### PR DESCRIPTION
## Summary
- implement new `data_pipeline.py` with config-driven feature generation, data loading and train/val/test split
- add pytest tests for moving average, splitting and missing value handling
- add CNN+LSTM `TrendPredictor` with training routine for supervised trend prediction
- add evaluation utils, saving/loading, prediction API, and model selection helper
- extend supervised model tests for saving/loading, evaluation, prediction, and selection
- augment trading env with model predictions and integrate them via new RLlib `ConcatModel`
- provide RL training example in `train_rl.py`
- add tests for env-model integration and policy model output shape
- configure Ray cluster usage and resource detection utilities
- **add Ray Serve deployment stubs** for predictor and policy models

## Testing
- `pytest -q tests/test_serve_deployment.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pytest -q` *(fails to import packages like pandas, torch, yaml, etc.)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68423bd4cf34832e97b0ed13ad84ffb4