### PR TITLE
Introduce dataclass configs for agents

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -3,6 +3,7 @@ from .trainer import Trainer
 from .sac_agent import SACAgent
 from .td3_agent import TD3Agent
 from .ensemble_agent import EnsembleAgent
+from .configs import SACConfig, TD3Config, EnsembleConfig
 
 # Legacy agents (deprecated placeholders)
 # TODO: Remove deprecated agents once transition is complete

--- a/src/agents/configs.py
+++ b/src/agents/configs.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass, field
+from typing import List, Dict, Any
+
+@dataclass
+class SACConfig:
+    """Configuration options for :class:`SACAgent`."""
+    learning_rate: float = 3e-4
+    gamma: float = 0.99
+    tau: float = 0.005
+    batch_size: int = 256
+    buffer_capacity: int = 1000000
+    hidden_dims: List[int] = field(default_factory=lambda: [256, 256])
+    automatic_entropy_tuning: bool = True
+    target_entropy: float = -1.0
+    alpha: float = 0.2  # Used when automatic_entropy_tuning is False
+
+@dataclass
+class TD3Config:
+    """Configuration options for :class:`TD3Agent`."""
+    learning_rate: float = 3e-4
+    gamma: float = 0.99
+    tau: float = 0.005
+    batch_size: int = 256
+    buffer_capacity: int = 1000000
+    hidden_dims: List[int] = field(default_factory=lambda: [256, 256])
+    policy_delay: int = 2
+    target_noise: float = 0.2
+    noise_clip: float = 0.5
+    exploration_noise: float = 0.1
+
+@dataclass
+class EnsembleConfig:
+    """Configuration options for :class:`EnsembleAgent`."""
+    agents: Dict[str, Dict[str, Any]] = field(default_factory=lambda: {
+        "sac": {"enabled": True, "config": None},
+        "td3": {"enabled": True, "config": None},
+    })
+    ensemble_method: str = "weighted_average"
+    weight_update_frequency: int = 1000
+    diversity_penalty: float = 0.1
+    min_weight: float = 0.1
+    performance_window: int = 100
+    risk_adjustment: bool = True

--- a/src/agents/ensemble_agent.py
+++ b/src/agents/ensemble_agent.py
@@ -16,6 +16,8 @@ import yaml
 from pathlib import Path
 import logging
 from collections import defaultdict, deque
+from dataclasses import asdict, is_dataclass
+from .configs import EnsembleConfig, SACConfig, TD3Config
 
 from .sac_agent import SACAgent
 from .td3_agent import TD3Agent
@@ -35,7 +37,7 @@ class EnsembleAgent:
     def __init__(self,
                  state_dim: int,
                  action_dim: int = 1,
-                 config: Optional[Union[str, Dict]] = None,
+                 config: Optional[Union[str, Dict, EnsembleConfig]] = None,
                  device: str = "cpu"):
         
         self.device = torch.device(device)
@@ -68,8 +70,8 @@ class EnsembleAgent:
         # Setup logging
         self.logger = logging.getLogger(__name__)
         
-    def _load_config(self, config: Optional[Union[str, Dict]]) -> Dict:
-        """Load configuration from file or dict."""
+    def _load_config(self, config: Optional[Union[str, Dict, EnsembleConfig]]) -> Dict:
+        """Load configuration from dataclass, file, or dict."""
         if config is None:
             return {
                 "agents": {
@@ -86,6 +88,8 @@ class EnsembleAgent:
         elif isinstance(config, str):
             with open(config, 'r') as f:
                 return yaml.safe_load(f) or {}
+        elif is_dataclass(config):
+            return asdict(config)
         else:
             return config
     

--- a/src/agents/sac_agent.py
+++ b/src/agents/sac_agent.py
@@ -20,6 +20,8 @@ import random
 from typing import Dict, List, Tuple, Optional, Union
 import yaml
 from pathlib import Path
+from dataclasses import asdict, is_dataclass
+from .configs import SACConfig
 
 
 class Actor(nn.Module):
@@ -147,10 +149,10 @@ class SACAgent:
     - Automatic temperature tuning
     """
     
-    def __init__(self, 
+    def __init__(self,
                  state_dim: int,
                  action_dim: int = 1,  # Position size
-                 config: Optional[Union[str, Dict]] = None,
+                 config: Optional[Union[str, Dict, SACConfig]] = None,
                  device: str = "cpu"):
         
         self.device = torch.device(device)
@@ -197,8 +199,8 @@ class SACAgent:
         # Training metrics
         self.training_step = 0
         
-    def _load_config(self, config: Optional[Union[str, Dict]]) -> Dict:
-        """Load configuration from file or dict."""
+    def _load_config(self, config: Optional[Union[str, Dict, SACConfig]]) -> Dict:
+        """Load configuration from dataclass, file, or dict."""
         if config is None:
             # Default configuration
             return {
@@ -214,6 +216,8 @@ class SACAgent:
         elif isinstance(config, str):
             with open(config, 'r') as f:
                 return yaml.safe_load(f) or {}
+        elif is_dataclass(config):
+            return asdict(config)
         else:
             return config
             

--- a/src/agents/td3_agent.py
+++ b/src/agents/td3_agent.py
@@ -19,6 +19,8 @@ import random
 from typing import Dict, List, Tuple, Optional, Union
 import yaml
 import copy
+from dataclasses import asdict, is_dataclass
+from .configs import TD3Config
 
 
 class Actor(nn.Module):
@@ -121,7 +123,7 @@ class TD3Agent:
     def __init__(self,
                  state_dim: int,
                  action_dim: int = 1,
-                 config: Optional[Union[str, Dict]] = None,
+                 config: Optional[Union[str, Dict, TD3Config]] = None,
                  device: str = "cpu"):
         
         self.device = torch.device(device)
@@ -163,8 +165,8 @@ class TD3Agent:
         self.training_step = 0
         self.total_iterations = 0
         
-    def _load_config(self, config: Optional[Union[str, Dict]]) -> Dict:
-        """Load configuration from file or dict."""
+    def _load_config(self, config: Optional[Union[str, Dict, TD3Config]]) -> Dict:
+        """Load configuration from dataclass, file, or dict."""
         if config is None:
             return {
                 "learning_rate": 3e-4,
@@ -181,6 +183,8 @@ class TD3Agent:
         elif isinstance(config, str):
             with open(config, 'r') as f:
                 return yaml.safe_load(f) or {}
+        elif is_dataclass(config):
+            return asdict(config)
         else:
             return config
     

--- a/tests/test_sac_agent.py
+++ b/tests/test_sac_agent.py
@@ -9,7 +9,8 @@ from unittest.mock import Mock, patch
 import tempfile
 import os
 
-from src.agents.sac_agent import SACAgent, Actor, Critic, ReplayBuffer, EXAMPLE_CONFIG
+from src.agents.sac_agent import SACAgent, Actor, Critic, ReplayBuffer
+from src.agents.configs import SACConfig
 
 
 class TestSACAgent:
@@ -18,16 +19,16 @@ class TestSACAgent:
     @pytest.fixture
     def agent_config(self):
         """Test configuration for SAC agent."""
-        return {
-            "learning_rate": 1e-3,
-            "gamma": 0.99,
-            "tau": 0.01,
-            "batch_size": 32,
-            "buffer_capacity": 1000,
-            "hidden_dims": [64, 64],
-            "automatic_entropy_tuning": True,
-            "target_entropy": -1.0
-        }
+        return SACConfig(
+            learning_rate=1e-3,
+            gamma=0.99,
+            tau=0.01,
+            batch_size=32,
+            buffer_capacity=1000,
+            hidden_dims=[64, 64],
+            automatic_entropy_tuning=True,
+            target_entropy=-1.0,
+        )
     
     @pytest.fixture
     def sac_agent(self, agent_config):

--- a/tests/test_td3_agent.py
+++ b/tests/test_td3_agent.py
@@ -11,7 +11,8 @@ from unittest.mock import patch, MagicMock
 import tempfile
 import os
 
-from src.agents.td3_agent import TD3Agent, TD3Config
+from src.agents.td3_agent import TD3Agent
+from src.agents.configs import TD3Config
 from src.envs.trading_env import TradingEnvironment
 
 
@@ -22,26 +23,27 @@ class TestTD3Agent:
     def td3_config(self):
         """Create test configuration for TD3 agent."""
         return TD3Config(
-            state_dim=10,
-            action_dim=3,
-            max_action=1.0,
-            discount=0.99,
+            learning_rate=3e-4,
+            gamma=0.99,
             tau=0.005,
-            policy_noise=0.2,
-            noise_clip=0.5,
-            policy_freq=2,
-            actor_lr=3e-4,
-            critic_lr=3e-4,
-            hidden_dim=64,
-            buffer_size=10000,
             batch_size=32,
-            exploration_noise=0.1
+            buffer_capacity=10000,
+            hidden_dims=[64, 64],
+            policy_delay=2,
+            target_noise=0.2,
+            noise_clip=0.5,
+            exploration_noise=0.1,
         )
     
     @pytest.fixture
     def td3_agent(self, td3_config):
         """Create TD3 agent instance."""
-        return TD3Agent(td3_config)
+        return TD3Agent(
+            state_dim=10,
+            action_dim=3,
+            config=td3_config,
+            device="cpu",
+        )
     
     @pytest.fixture
     def sample_state(self):
@@ -388,41 +390,46 @@ class TestTD3Agent:
 
 class TestTD3Config:
     """Test cases for TD3 configuration."""
-    
+
     def test_default_config(self):
         """Test default configuration values."""
-        config = TD3Config(state_dim=10, action_dim=3)
-        
-        assert config.state_dim == 10
-        assert config.action_dim == 3
-        assert config.max_action == 1.0
-        assert config.discount == 0.99
+        config = TD3Config()
+
+        assert config.learning_rate == 3e-4
+        assert config.gamma == 0.99
         assert config.tau == 0.005
-        assert config.policy_noise == 0.2
+        assert config.batch_size == 256
+        assert config.buffer_capacity == 1000000
+        assert config.policy_delay == 2
+        assert config.target_noise == 0.2
         assert config.noise_clip == 0.5
-        assert config.policy_freq == 2
-    
+        assert config.exploration_noise == 0.1
+
     def test_custom_config(self):
         """Test custom configuration values."""
         config = TD3Config(
-            state_dim=20,
-            action_dim=5,
-            max_action=2.0,
-            discount=0.95,
+            learning_rate=1e-3,
+            gamma=0.95,
             tau=0.01,
-            policy_noise=0.1,
+            batch_size=64,
+            buffer_capacity=5000,
+            hidden_dims=[128, 128],
+            policy_delay=3,
+            target_noise=0.1,
             noise_clip=0.3,
-            policy_freq=3
+            exploration_noise=0.2,
         )
-        
-        assert config.state_dim == 20
-        assert config.action_dim == 5
-        assert config.max_action == 2.0
-        assert config.discount == 0.95
+
+        assert config.learning_rate == 1e-3
+        assert config.gamma == 0.95
         assert config.tau == 0.01
-        assert config.policy_noise == 0.1
+        assert config.batch_size == 64
+        assert config.buffer_capacity == 5000
+        assert config.hidden_dims == [128, 128]
+        assert config.policy_delay == 3
+        assert config.target_noise == 0.1
         assert config.noise_clip == 0.3
-        assert config.policy_freq == 3
+        assert config.exploration_noise == 0.2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add dataclasses `SACConfig`, `TD3Config`, and `EnsembleConfig`
- expose new dataclasses through `src.agents`
- allow SAC, TD3 and Ensemble agents to accept dataclass configs
- update tests to use new dataclass configurations

## Testing
- `pytest tests/test_sac_agent.py tests/test_td3_agent.py tests/test_ensemble_agent.py -q` *(fails: ModuleNotFoundError: No module named 'gym')*

------
https://chatgpt.com/codex/tasks/task_e_6845cd969014832e9b89bac9f08cc8b5