### PR TITLE
Add TradingEnv test coverage

### DIFF
--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,6 +1,25 @@
-"""Test data loading utilities (placeholder)."""
+import pandas as pd
+import numpy as np
 
-# TODO: cover edge cases for CSV ingestion and feature generation.
+from src.data_pipeline import load_data
 
-def test_data_loader_placeholder():
-    assert True
+
+def test_load_csv_parses_columns_and_dtypes(tmp_path):
+    data = pd.DataFrame({
+        "timestamp": pd.date_range("2021-01-01", periods=3, freq="D"),
+        "open": np.arange(3, dtype=float),
+        "high": np.arange(3, dtype=float) + 1,
+        "low": np.arange(3, dtype=float) - 1,
+        "close": np.arange(3, dtype=float) + 2,
+        "volume": np.arange(3, dtype=int),
+    })
+    csv = tmp_path / "data.csv"
+    data.to_csv(csv, index=False)
+
+    loaded = load_data({"type": "csv", "path": str(csv)})
+
+    assert list(loaded.columns) == list(data.columns)
+    assert pd.api.types.is_datetime64_any_dtype(loaded["timestamp"])
+    for col in ["open", "high", "low", "close", "volume"]:
+        assert pd.api.types.is_numeric_dtype(loaded[col])
+

--- a/tests/test_env_resets.py
+++ b/tests/test_env_resets.py
@@ -1,6 +1,42 @@
-"""Test environment reset behavior (placeholder)."""
+import pandas as pd
+import numpy as np
 
-# TODO: ensure consistent resets across episodes and random seeds.
+from src.envs.trading_env import TradingEnv
 
-def test_env_reset_placeholder():
-    assert True
+
+def create_env(tmp_path):
+    df = pd.DataFrame({
+        "open": np.arange(6, dtype=float),
+        "high": np.arange(6, dtype=float),
+        "low": np.arange(6, dtype=float),
+        "close": np.arange(6, dtype=float),
+        "volume": np.ones(6),
+    })
+    csv = tmp_path / "prices.csv"
+    df.to_csv(csv, index=False)
+    cfg = {"dataset_paths": [str(csv)], "window_size": 2, "initial_balance": 500, "transaction_cost": 0.0}
+    return TradingEnv(cfg)
+
+
+def test_reset_restores_state(tmp_path):
+    env = create_env(tmp_path)
+    env.reset()
+    env.step(1)
+    assert env.position != 0
+    assert env.balance != env.initial_balance
+
+    obs, _ = env.reset()
+    assert env.position == 0
+    assert env.balance == env.initial_balance
+    assert env.current_step == env.window_size
+    assert obs.shape == (env.window_size, env.data.shape[1])
+
+
+def test_reset_with_seed_reproducible(tmp_path):
+    env = create_env(tmp_path)
+    env.reset(seed=123)
+    val1 = env.np_random.random()
+    env.reset(seed=123)
+    val2 = env.np_random.random()
+    assert np.isclose(val1, val2)
+

--- a/tests/test_reward_calculation.py
+++ b/tests/test_reward_calculation.py
@@ -1,7 +1,41 @@
-"""Test reward calculation logic in TradingEnv (placeholder)."""
+import pandas as pd
+import numpy as np
 
-# TODO: implement unit tests validating reward computation with
-# transaction costs and slippage.
+from src.envs.trading_env import TradingEnv
 
-def test_reward_placeholder():
-    assert True
+
+def make_env(tmp_path, closes, tc=0.1):
+    df = pd.DataFrame({
+        "open": closes,
+        "high": closes,
+        "low": closes,
+        "close": closes,
+        "volume": np.ones(len(closes)),
+    })
+    csv = tmp_path / "prices.csv"
+    df.to_csv(csv, index=False)
+    cfg = {"dataset_paths": [str(csv)], "window_size": 2, "transaction_cost": tc, "initial_balance": 1000}
+    return TradingEnv(cfg)
+
+
+def test_reward_computation_buy_hold_sell(tmp_path):
+    closes = np.arange(1.0, 7.0)
+    env = make_env(tmp_path, closes)
+
+    env.reset()
+
+    # Buy
+    _, reward_buy, _, _, _ = env.step(1)
+    expected_buy = (closes[2] - closes[1]) - 0.1
+    assert np.isclose(reward_buy, expected_buy)
+
+    # Hold
+    _, reward_hold, _, _, _ = env.step(0)
+    expected_hold = (closes[3] - closes[2])
+    assert np.isclose(reward_hold, expected_hold)
+
+    # Sell
+    _, reward_sell, _, _, _ = env.step(2)
+    expected_sell = (-1 * (closes[4] - closes[3])) - 0.2
+    assert np.isclose(reward_sell, expected_sell)
+


### PR DESCRIPTION
## Summary
- expand data loader tests to verify CSV parsing
- validate TradingEnv reward calculations with deterministic prices
- check TradingEnv reset behaviour and seeding

## Testing
- `pytest tests/test_data_loader.py tests/test_reward_calculation.py tests/test_env_resets.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68484cf1af78832eb52b673d7a85f934