### PR TITLE
Trim loops & mark integration tests

### DIFF
--- a/tests/test_feature_pipeline.py
+++ b/tests/test_feature_pipeline.py
@@ -5,6 +5,8 @@ import pandas as pd
 import numpy as np
 import pytest
 
+pytestmark = pytest.mark.integration
+
 from src.data.features import generate_features
 from src.data.synthetic import generate_gbm_prices
 
@@ -115,7 +117,7 @@ def test_pipeline_memory_usage():
     initial_memory = process.memory_info().rss / 1024 / 1024  # MB
     
     # Create a large synthetic dataset
-    n_days = 1000
+    n_days = 200
     df = generate_gbm_prices(
         n_days=n_days,
         mu=0.0001,

--- a/tests/test_ray_integration.py
+++ b/tests/test_ray_integration.py
@@ -4,12 +4,16 @@ import numpy as np
 import pandas as pd
 import gymnasium as gym
 
+import pytest
+
 # Patch gym before importing the environment module
 sys.modules["gym"] = gym
 
 import ray
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.tune.registry import register_env
+
+pytestmark = pytest.mark.integration
 from src.envs.trading_env import env_creator
 
 class FlattenWrapper(gym.ObservationWrapper):

--- a/tests/test_sac_agent.py
+++ b/tests/test_sac_agent.py
@@ -266,6 +266,7 @@ class TestReplayBuffer:
         assert len(buffer) == 3
 
 
+@pytest.mark.integration
 class TestSACIntegration:
     """Integration tests for SAC agent."""
     
@@ -283,7 +284,7 @@ class TestSACIntegration:
         )
         
         # Collect experiences
-        for _ in range(50):
+        for _ in range(20):
             state = np.random.randn(5)
             action = agent.select_action(state, evaluate=False)
             reward = np.random.randn()

--- a/tests/test_td3_agent.py
+++ b/tests/test_td3_agent.py
@@ -137,15 +137,15 @@ class TestTD3Agent:
         assert td3_agent.replay_buffer.size == 1
         
         # Add more experiences
-        for _ in range(100):
+        for _ in range(20):
             state = np.random.randn(10).astype(np.float32)
             action = np.random.uniform(-1, 1, 3).astype(np.float32)
             reward = np.random.randn()
             next_state = np.random.randn(10).astype(np.float32)
             done = np.random.choice([True, False])
             td3_agent.replay_buffer.add(state, action, reward, next_state, done)
-        
-        assert td3_agent.replay_buffer.size == 101
+
+        assert td3_agent.replay_buffer.size == 21
     
     def test_train_step(self, td3_agent, sample_batch):
         """Test training step."""
@@ -366,7 +366,7 @@ class TestTD3Agent:
         
         # After training, they should learn different functions
         # Fill buffer and train
-        for _ in range(100):
+        for _ in range(20):
             s = np.random.randn(10).astype(np.float32)
             a = np.random.uniform(-1, 1, 3).astype(np.float32)
             r = np.random.randn()

--- a/tests/test_td3_integration.py
+++ b/tests/test_td3_integration.py
@@ -6,6 +6,8 @@ Tests the complete pipeline from config to training.
 import pytest
 import numpy as np
 import torch
+
+pytestmark = pytest.mark.integration
 from src.agents.td3_agent import TD3Agent
 from src.agents.configs import TD3Config
 from src.envs.trading_env import TradingEnv

--- a/tests/test_trading_env_model_integration.py
+++ b/tests/test_trading_env_model_integration.py
@@ -3,6 +3,8 @@ import pandas as pd
 import pytest
 import torch
 
+pytestmark = pytest.mark.integration
+
 from src.envs.trading_env import TradingEnv
 from src.supervised_model import TrendPredictor, ModelConfig, save_model
 

--- a/tests/test_train_cnn_lstm.py
+++ b/tests/test_train_cnn_lstm.py
@@ -7,6 +7,8 @@ import pytest
 import numpy as np
 import pandas as pd
 import torch
+
+pytestmark = pytest.mark.integration
 import tempfile
 import yaml
 from pathlib import Path


### PR DESCRIPTION
## Summary
- speed up TD3 and SAC unit tests by reducing buffer population loops
- mark heavy test suites as integration
- shrink data size in feature pipeline memory test

## Testing
- `pytest tests/test_td3_agent.py::TestTD3Agent::test_replay_buffer_storage -q`
- `pytest tests/test_sac_agent.py::TestSACIntegration::test_training_loop -q`
- `pytest tests/test_feature_pipeline.py::test_pipeline_memory_usage -q`


------
https://chatgpt.com/codex/tasks/task_e_6848579f1118832ebb4bb9bde38d6cd4