### PR TITLE
Add data fixture for TD3 tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+import pandas as pd
+from generate_sample_data import generate_sample_price_data
+
+@pytest.fixture(scope="session")
+def sample_csv_path(tmp_path_factory):
+    data_dir = tmp_path_factory.mktemp("data")
+    file_path = data_dir / "sample.csv"
+    df = generate_sample_price_data(symbol="TEST", days=30, start_price=100.0, volatility=0.01)
+    df = df.drop(columns=["timestamp", "symbol"])
+    df.to_csv(file_path, index=False)
+    return str(file_path)

--- a/tests/test_td3_integration.py
+++ b/tests/test_td3_integration.py
@@ -17,10 +17,10 @@ class TestTD3Integration:
     """Integration tests for TD3 agent with trading environment."""
     
     @pytest.fixture
-    def trading_env(self):
+    def trading_env(self, sample_csv_path):
         """Create a trading environment for testing."""
         env_cfg = {
-            "dataset_paths": ["data/sample_training_data_simple_20250607_192034.csv"],
+            "dataset_paths": [sample_csv_path],
             "window_size": 10,
             "initial_balance": 10000,
             "transaction_cost": 0.001,


### PR DESCRIPTION
## Summary
- provide a fixture that generates a temporary sample CSV for tests
- update `test_td3_integration` to use the fixture instead of a hard-coded path

## Testing
- `pytest -k td3_integration -q` *(fails: IndexError: tuple index out of range)*

------
https://chatgpt.com/codex/tasks/task_e_6848748ae830832eaed6dbe98d3b9617