### PR TITLE
Expand template config and defaults

### DIFF
--- a/src/configs/template_config.yaml
+++ b/src/configs/template_config.yaml
@@ -1,2 +1,25 @@
 # Base configuration file
-# TODO: externalize hyper-parameters, symbols, and date ranges here
+
+# Dataset paths for training, validation, and testing
+data:
+  train_path: data/train.csv
+  val_path: data/val.csv
+  test_path: data/test.csv
+
+# Default model hyperparameters
+model:
+  cnn_filters: [32, 64]
+  cnn_kernel_sizes: [3, 3]
+  lstm_units: 128
+  dropout: 0.5
+  use_attention: false
+  output_size: 1
+
+# Training options
+training:
+  batch_size: 32
+  learning_rate: 0.001
+  epochs: 10
+  early_stopping_patience: 5
+  sequence_length: 60
+  prediction_horizon: 1

--- a/tests/test_template_config.py
+++ b/tests/test_template_config.py
@@ -1,0 +1,22 @@
+import yaml
+from src.training.train_cnn_lstm import TrainingConfig, load_template_config
+
+
+def test_template_file_parses():
+    cfg = load_template_config()
+    assert 'data' in cfg
+    assert 'model' in cfg
+    assert 'training' in cfg
+
+
+def test_training_config_from_template():
+    cfg = TrainingConfig.from_template()
+    # values taken from template_config.yaml
+    assert cfg.train_path == 'data/train.csv'
+    assert cfg.val_path == 'data/val.csv'
+    assert cfg.test_path == 'data/test.csv'
+    assert cfg.batch_size == 32
+    assert cfg.learning_rate == 0.001
+    assert cfg.epochs == 10
+    assert cfg.model_config is not None
+    assert cfg.model_config.get('cnn_filters') == [32, 64]


### PR DESCRIPTION
## Summary
- expand `template_config.yaml` with dataset, model, and training fields
- load defaults from the template in `train_cnn_lstm.py`
- expose `TrainingConfig.from_template`
- add tests for template parsing

## Testing
- `pytest tests/test_template_config.py -v`
- `pytest tests/test_data_pipeline.py tests/test_trading_env.py tests/test_features.py -v`

------
https://chatgpt.com/codex/tasks/task_e_684b280f429c832ea42142c668864a0d