### PR TITLE
Add evaluation script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,18 @@ python src/train_rl.py --agent td3
 python src/train_rl.py --agent ensemble
 ```
 
+### Evaluation
+After training, evaluate a saved agent checkpoint using `evaluate_agent.py`:
+
+```bash
+python evaluate_agent.py --data data/sample_data.csv \
+    --checkpoint checkpoints/agent.pth --agent sac \
+    --output results/evaluation.json
+```
+
+The resulting metrics JSON is described in
+[`docs/EVALUATION_GUIDE.md`](docs/EVALUATION_GUIDE.md).
+
 ## Testing
 
 **All 321 tests passing! ✅**

--- a/docs/EVALUATION_GUIDE.md
+++ b/docs/EVALUATION_GUIDE.md
@@ -1,0 +1,55 @@
+# Agent Evaluation Guide
+
+This document explains how to evaluate a trained trading agent using the
+`evaluate_agent.py` script introduced in this repository. The evaluation
+process measures trading performance on historical data and stores metrics
+for further analysis.
+
+## Usage
+
+```
+python evaluate_agent.py --data path/to/market_data.csv \
+    --checkpoint path/to/agent_checkpoint.pth \
+    --agent sac \
+    --output results/evaluation.json
+```
+
+Arguments:
+- `--data` – CSV file containing the market data used for evaluation.
+- `--checkpoint` – File path to the saved agent parameters.
+- `--agent` – Type of agent to load (`sac`, `td3`, or `ensemble`).
+- `--output` – Where to write the resulting metrics JSON (default `results/evaluation.json`).
+- `--window-size` – Observation window length (defaults to 50).
+
+The script will load the dataset, initialize a `TradingEnv`, run one full
+trading episode using the selected agent, and compute metrics such as
+Sharpe ratio and maximum drawdown. The resulting dictionary is written to
+the specified output file.
+
+## Output
+
+An example output file `results/evaluation.json` looks like this:
+
+```json
+{
+  "sharpe_ratio": 1.25,
+  "sortino_ratio": 2.10,
+  "max_drawdown": 0.12,
+  "profit_factor": 1.8,
+  "win_rate": 0.55,
+  "calmar_ratio": 1.3,
+  "total_return": 0.35,
+  "volatility": 0.2,
+  "num_trades": 120
+}
+```
+
+These metrics come from `src/utils/metrics.py` and provide a quick snapshot
+of strategy quality. Higher Sharpe and Sortino ratios generally indicate a
+better risk-adjusted return.
+
+## Notebook Example
+
+See [`evaluation_example.ipynb`](../evaluation_example.ipynb) for a brief
+walkthrough of running the evaluation script inside a Jupyter notebook and
+visualizing the resulting metrics.

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,10 @@ This directory contains comprehensive documentation for the Trading RL Agent pro
 **High level architecture and RL agent interactions**
 - Data pipeline, `TradingEnv`, SAC/TD3, and ensemble overview
 
+#### [`EVALUATION_GUIDE.md`](EVALUATION_GUIDE.md)
+**How to evaluate trained agents and interpret metrics**
+
+
 ## 🎯 Quick Navigation
 
 ### For New Developers

--- a/evaluate_agent.py
+++ b/evaluate_agent.py
@@ -1,0 +1,127 @@
+"""Evaluate a trained agent on historical data and report metrics.
+
+This script loads a saved agent checkpoint, runs it through ``TradingEnv``
+on the provided dataset, and computes common performance metrics such as
+Sharpe ratio and maximum drawdown. Results are stored in a JSON file for
+later analysis.
+
+Example
+-------
+```
+python evaluate_agent.py --data data/sample_data.csv --checkpoint sac_agent.pth \
+    --agent sac --output results/evaluation.json
+```
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+from src.envs.trading_env import TradingEnv
+from src.utils import metrics
+from src.agents.sac_agent import SACAgent
+from src.agents.td3_agent import TD3Agent
+from src.agents.ensemble_agent import EnsembleAgent
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate a trained trading agent")
+    parser.add_argument(
+        "--data", type=str, required=True, help="CSV dataset for evaluation"
+    )
+    parser.add_argument(
+        "--checkpoint", type=str, required=True, help="Agent checkpoint path"
+    )
+    parser.add_argument(
+        "--agent",
+        type=str,
+        default="sac",
+        choices=["sac", "td3", "ensemble"],
+        help="Type of agent to load",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="results/evaluation.json",
+        help="Path to save metrics JSON",
+    )
+    parser.add_argument(
+        "--window-size", type=int, default=50, help="Observation window size"
+    )
+    return parser.parse_args()
+
+
+def load_agent(agent_type: str, state_dim: int, action_dim: int, checkpoint: str):
+    if agent_type == "sac":
+        agent = SACAgent(state_dim=state_dim, action_dim=action_dim)
+    elif agent_type == "td3":
+        agent = TD3Agent(state_dim=state_dim, action_dim=action_dim)
+    else:
+        # Ensemble agent combines SAC and TD3 internally
+        agent = EnsembleAgent(state_dim=state_dim, action_dim=action_dim)
+    agent.load(checkpoint)
+    return agent
+
+
+def run_episode(env: TradingEnv, agent) -> list[float]:
+    state, _ = env.reset()
+    rewards: list[float] = []
+    done = False
+    while not done:
+        obs = state
+        if isinstance(obs, dict):
+            # flatten dictionary observation for agent
+            market = obs.get("market_features", np.array([])).flatten()
+            model = obs.get("model_pred", np.array([])).flatten()
+            obs = np.concatenate([market, model])
+        action = agent.select_action(np.asarray(obs), evaluate=True)
+        state, reward, done, _, _ = env.step(action)
+        rewards.append(float(reward))
+    return rewards
+
+
+def main() -> None:
+    args = parse_args()
+
+    env_cfg = {
+        "dataset_paths": [args.data],
+        "window_size": args.window_size,
+        "continuous_actions": True,
+        "model_path": None,
+    }
+    env = TradingEnv(env_cfg)
+
+    if isinstance(env.observation_space, dict) or hasattr(
+        env.observation_space, "spaces"
+    ):
+        state_dim = int(np.prod(env.observation_space["market_features"].shape))
+        if env.model_output_size:
+            state_dim += env.model_output_size
+    else:
+        state_dim = int(np.prod(env.observation_space.shape))
+    action_dim = (
+        env.action_space.shape[0]
+        if hasattr(env.action_space, "shape")
+        else env.action_space.n
+    )
+
+    agent = load_agent(args.agent, state_dim, action_dim, args.checkpoint)
+
+    rewards = run_episode(env, agent)
+    equity = np.cumprod(1 + np.array(rewards))
+    results = metrics.calculate_risk_metrics(np.array(rewards), equity)
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w") as f:
+        json.dump(results, f, indent=2)
+
+    print("Saved evaluation metrics to", output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluation_example.ipynb
+++ b/evaluation_example.ipynb
@@ -1,0 +1,52 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Evaluating a Trained RL Agent\n",
+    "\n",
+    "This notebook demonstrates how to run `evaluate_agent.py` on a sample dataset and view the resulting metrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "source": [
+    "!python evaluate_agent.py --data data/sample_data.csv \\\n    --checkpoint checkpoints/agent.pth --agent sac --output results/evaluation.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After running the script, the metrics file `results/evaluation.json` can be loaded and displayed:" 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "source": [
+    "import json\n",
+    "with open('results/evaluation.json') as f:\n",
+    "    metrics = json.load(f)\n",
+    "metrics"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `evaluate_agent.py` for scoring trained RL checkpoints
- document evaluation workflow in `docs/EVALUATION_GUIDE.md`
- link evaluation guide in docs index and README
- provide an evaluation example notebook

## Testing
- `pip install pandas torch` *(passed)*
- `pytest -q` *(failed: ModuleNotFoundError: feedparser, requests, ray, torch, yaml, gymnasium)*

------
https://chatgpt.com/codex/tasks/task_e_685357f127ac832e979bf322f719a068