### PR TITLE
Clarify capabilities and planned features

### DIFF
--- a/CLEANUP_PLAN.md
+++ b/CLEANUP_PLAN.md
@@ -142,7 +142,7 @@ Our system uses a **two-tier hybrid approach**:
 - **Portfolio Performance**: Sharpe ratio >1.5 on multi-asset portfolio
 - **Risk Management**: Maximum drawdown <15%, VaR compliance >95%
 - **Scalability**: Support for 50+ assets with <100ms latency
-- **Reliability**: 99.9% uptime with automatic failover
+- **Reliability**: Goal to add failover support; uptime metrics not yet measured
 
 ### **Integration Metrics**
 
@@ -235,9 +235,9 @@ Our system uses a **two-tier hybrid approach**:
 
 ## 🎯 **CONCLUSION**
 
-This comprehensive plan builds upon our proven hybrid CNN+LSTM + RL foundation to create a world-class multi-asset portfolio optimization system. The phased approach ensures systematic development while maintaining our high standards of testing, documentation, and production readiness.
+This comprehensive plan builds upon our proven hybrid CNN+LSTM + RL foundation to create a multi-asset portfolio optimization system. The phased approach ensures systematic development while maintaining our high standards of testing, documentation, and production readiness.
 
-**Key Innovation**: We've successfully demonstrated that supervised learning can significantly enhance reinforcement learning in financial markets. Phase 3 will scale this innovation to full portfolio management while adding enterprise-grade production capabilities.
+**Key Innovation**: We've successfully demonstrated that supervised learning can significantly enhance reinforcement learning in financial markets. Phase 3 will scale this innovation to full portfolio management while adding additional production capabilities.
 
 **Timeline**: 12 weeks to complete Phase 3, resulting in a production-ready multi-asset trading system that combines the best of supervised learning, reinforcement learning, and modern MLOps practices.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Enterprise Trading RL System - Production Grade
+# Trading RL System
 
-A **production-ready algorithmic trading system** following 2024 industry standards that combines **CNN+LSTM market intelligence** with **reinforcement learning optimization**, built on proven frameworks used by major financial institutions.
+This project combines **CNN+LSTM market intelligence** with **reinforcement learning optimization** using open-source frameworks.
 
 ## 🏆 Industry Standards & Compliance
 
-**Built with frameworks used by JPMorgan, Goldman Sachs, and leading hedge funds:**
+**Built with open-source frameworks commonly used in the industry:**
 
 - **FinRL Foundation**: Industry-standard RL trading framework
 - **Ray RLlib**: Distributed training used by Uber, Shopify, major hedge funds
-- **Professional Data**: Bloomberg, Refinitiv, Polygon.io integration
-- **Enterprise Risk Management**: Real-time VaR, position limits, circuit breakers
+- **Professional Data**: Alpaca support with placeholders for Bloomberg, Refinitiv, and Polygon.io
+- **Risk Management**: Position limits with experimental VaR and circuit breaker components
 - **MLOps Governance**: Model versioning, A/B testing, automated retraining
 - **Regulatory Compliance**: MiFID II, audit trails, performance attribution
 
@@ -56,20 +56,20 @@ production_state = {
 | **Market Data Pipeline**   | ✅ Production | Kafka + Spark real-time         |
 | **CNN+LSTM Intelligence**  | ✅ Production | 1.37M records, 97.78% quality   |
 | **RL Optimization**        | ✅ Production | FinRL + Ray RLlib               |
-| **Risk Management**        | ✅ Production | Real-time VaR, circuit breakers |
+| **Risk Management**        | 🚧 Experimental | Position limits; VaR and circuit breakers planned |
 | **MLOps Pipeline**         | ✅ Production | MLflow + Kubernetes             |
-| **Professional Data**      | ✅ Production | Bloomberg, Alpaca APIs          |
+| **Professional Data**      | 🚧 In progress | Alpaca implemented; Bloomberg planned |
 | **Backtesting Engine**     | ✅ Production | Transaction costs, slippage     |
 | **Performance Monitoring** | ✅ Production | Prometheus + Grafana            |
 
-**SLA**: 99.9% uptime | **Latency**: <100ms decisions | **Tests**: 100+ passing (Environment tests fixed)
+Latency: <100ms decisions in sample environment | Tests: 100+ passing. No formal uptime guarantee.
 
 ## 🚀 Enterprise Quick Start
 
 ### 1. Production Installation
 
 ```bash
-# Install enterprise-grade frameworks
+# Install required frameworks
 # Clone repository
 git clone https://github.com/your-org/trading-rl-agent.git
 cd trading-rl-agent
@@ -172,7 +172,7 @@ trading-rl-agent/
 
 - **Portfolio-Level Optimization**: Extend to multiple assets simultaneously
 - **Cross-Asset Correlation**: Inter-asset relationship modeling with shared CNN layers
-- **Advanced Risk Management**: VaR, drawdown limits, sector constraints
+- **Advanced Risk Management**: Planned features include VaR, drawdown limits, and sector constraints
 - **Real-Time Deployment**: Production inference pipeline with streaming data
 
 ### Research Innovation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -103,7 +103,7 @@ All core functionality working - environment testing framework complete!
 
 ### **3.4 Production Deployment (Weeks 10-12)**
 
-**🏭 Enterprise Deployment**
+**🏭 Deployment**
 
 - **Containerization**: Kubernetes deployment with auto-scaling
 - **Monitoring**: Comprehensive performance tracking and alerting
@@ -140,7 +140,7 @@ All core functionality working - environment testing framework complete!
 - **Portfolio Performance**: Sharpe ratio >1.5 on multi-asset portfolio
 - **Risk Management**: Maximum drawdown <15%, VaR compliance >95%
 - **Scalability**: Support for 50+ assets with <100ms latency
-- **Reliability**: 99.9% uptime with automatic failover
+- **Reliability**: Goal to add failover support; uptime metrics not yet measured
 
 ---
 

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -1,10 +1,10 @@
-# Industry-Grade Hybrid Trading RL System
+# Hybrid Trading RL System
 
-## 🎯 Production-Ready Design Philosophy
+## 🎯 Design Philosophy
 
-The Trading RL Agent implements a **production-grade hybrid architecture** following industry standards and proven fintech practices. This system combines CNN+LSTM supervised learning with reinforcement learning optimization, built on enterprise-grade frameworks and infrastructure.
+The Trading RL Agent implements a hybrid architecture using widely adopted open-source tools. It combines CNN+LSTM supervised learning with reinforcement learning optimization.
 
-## 🏗️ Enterprise Architecture Stack
+## 🏗️ Architecture Stack
 
 ### **Framework Foundation**
 
@@ -17,9 +17,9 @@ The Trading RL Agent implements a **production-grade hybrid architecture** follo
 
 ```yaml
 Data Pipeline: Apache Kafka + Apache Spark
-Market Data: Bloomberg API / Refinitiv / Polygon.io (replacing yfinance)
+Market Data: Alpaca (implemented) with placeholders for Bloomberg, Refinitiv, Polygon.io
 Model Training: Ray RLlib + FinRL environments
-Risk Management: Real-time monitoring with circuit breakers
+Risk Management: Planned monitoring with circuit breakers
 Deployment: Kubernetes + Docker containers
 Monitoring: Prometheus + Grafana + MLflow
 Database: InfluxDB (time series) + PostgreSQL (metadata)
@@ -83,7 +83,7 @@ ProductionCNNLSTMModel(
 
 #### **Production Training Pipeline**
 
-- **Data Sources**: Professional market data feeds (Bloomberg, Refinitiv)
+- **Data Sources**: Alpaca data feed with planned support for Bloomberg and Refinitiv
 - **Distributed Training**: Ray Tune + Optuna for hyperparameter optimization
 - **Model Governance**: Automated retraining, A/B testing, version control
 - **Risk Validation**: Walk-forward testing with transaction costs and slippage


### PR DESCRIPTION
## Summary
- tone down marketing language in README, CLEANUP_PLAN, ROADMAP, and docs
- indicate Bloomberg and VaR integrations are planned or experimental
- remove uptime claims and enterprise references

## Testing
- `pytest -q` *(fails: TypeError in environment tests)*

------
https://chatgpt.com/codex/tasks/task_e_6860623b62f8832ea51227f65c67e357