### PR TITLE
Cleanup legacy test helpers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,23 +103,19 @@ def finrl_trading_env(finrl_sample_data):
 
 @pytest.fixture
 def sample_csv_file(tmp_path):
-    """Provide a sample CSV file for legacy compatibility tests."""
-    # Minimal CSV data for TraderEnv compatibility
-    np.random.seed(42)
+    """Provide a sample CSV file using ``TestDataManager`` utilities."""
+    from tests.test_data_utils import TestDataManager
+    import pandas as pd
 
-    data = pd.DataFrame(
-        {
-            "open": np.random.uniform(95, 105, 50),
-            "high": np.random.uniform(100, 110, 50),
-            "low": np.random.uniform(90, 100, 50),
-            "close": np.random.uniform(95, 105, 50),
-            "volume": np.random.randint(1000, 10000, 50),
-        }
-    )
+    manager = TestDataManager(str(tmp_path))
+    df = manager.generate_synthetic_dataset()
+    df = df.drop(columns=["timestamp"])  # TraderEnv expects numeric columns
+    dataset_path = tmp_path / "sample_test_data.csv"
+    df.to_csv(dataset_path, index=False)
+    manager.temp_files.append(dataset_path)
 
-    csv_path = tmp_path / "sample_test_data.csv"
-    data.to_csv(csv_path, index=False)
-    return str(csv_path)
+    yield str(dataset_path)
+    manager.cleanup()
 
 
 @pytest.fixture

--- a/tests/conftest_comprehensive.py
+++ b/tests/conftest_comprehensive.py
@@ -157,27 +157,37 @@ def multi_symbol_data():
 
 @pytest.fixture
 def sample_csv_path(tmp_path):
-    """Create a temporary CSV file with sample data for testing."""
-    df = generate_sample_price_data(
-        symbol="TEST", days=30, start_price=100.0, volatility=0.01
-    )
-    df = df.drop(columns=["timestamp", "symbol"])
+    """Create a temporary CSV file with ``TestDataManager``."""
+    from tests.test_data_utils import TestDataManager
+    import pandas as pd
+
+    manager = TestDataManager(str(tmp_path))
+    df = manager.generate_synthetic_dataset()
+    df = df.drop(columns=["timestamp"])  # Keep numeric columns only
     file_path = tmp_path / "sample.csv"
     df.to_csv(file_path, index=False)
-    return str(file_path)
+    manager.temp_files.append(file_path)
+
+    yield str(file_path)
+    manager.cleanup()
 
 
 @pytest.fixture(scope="session")
 def sample_csv_path_session(tmp_path_factory):
-    """Legacy fixture for backward compatibility - session scoped."""
+    """Session-scoped CSV path generated with ``TestDataManager``."""
+    from tests.test_data_utils import TestDataManager
+    import pandas as pd
+
     data_dir = tmp_path_factory.mktemp("data")
+    manager = TestDataManager(str(data_dir))
+    df = manager.generate_synthetic_dataset()
+    df = df.drop(columns=["timestamp"])  # Numeric columns only
     file_path = data_dir / "sample.csv"
-    df = generate_sample_price_data(
-        symbol="TEST", days=30, start_price=100.0, volatility=0.01
-    )
-    df = df.drop(columns=["timestamp", "symbol"])
     df.to_csv(file_path, index=False)
-    return str(file_path)
+    manager.temp_files.append(file_path)
+
+    yield str(file_path)
+    manager.cleanup()
 
 
 @pytest.fixture

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -227,33 +227,3 @@ def get_dynamic_test_config(
     return config
 
 
-# Legacy functions for backward compatibility
-def generate_synthetic_test_data(path=None, days=30, num_assets=3):
-    """Legacy function - maintained for backward compatibility."""
-    if path is None:
-        path = Path("data/synthetic_test_data.csv")
-    else:
-        path = Path(path)
-    start_date = datetime(2025, 1, 1)
-    dates = [start_date + timedelta(days=i) for i in range(days)]
-    data = {
-        "timestamp": [d.strftime("%Y-%m-%d") for d in dates for _ in range(num_assets)],
-        "symbol": [f"SYM{i}" for i in range(num_assets)] * days,
-        "open": np.random.uniform(100, 200, days * num_assets),
-        "high": np.random.uniform(100, 200, days * num_assets),
-        "low": np.random.uniform(90, 199, days * num_assets),
-        "close": np.random.uniform(100, 200, days * num_assets),
-        "volume": np.random.randint(1000, 10000, days * num_assets),
-        "label": np.random.choice([0, 1, 2], days * num_assets),
-    }
-    df = pd.DataFrame(data)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    df.to_csv(path, index=False)
-    return str(path)
-
-
-def cleanup_synthetic_test_data(path="data/synthetic_test_data.csv"):
-    """Legacy function - maintained for backward compatibility."""
-    p = Path(path)
-    if p.exists():
-        p.unlink()

--- a/tests/test_data_utils_new.py
+++ b/tests/test_data_utils_new.py
@@ -171,29 +171,3 @@ def get_dynamic_test_config(
     return config
 
 
-# Legacy functions for backward compatibility
-def generate_synthetic_test_data(path=None, days=30, num_assets=3):
-    """Legacy function for backward compatibility."""
-    manager = DataManager()
-    df = manager.generate_synthetic_dataset(n_days=days)
-
-    if path is None:
-        path = "data/synthetic_test_data.csv"
-
-    # Ensure directory exists
-    Path(path).parent.mkdir(parents=True, exist_ok=True)
-    df.to_csv(path, index=False)
-
-    logger.info(f"Generated synthetic test data: {path}")
-    return path
-
-
-def cleanup_synthetic_test_data(path="data/synthetic_test_data.csv"):
-    """Legacy function for backward compatibility."""
-    file_path = Path(path)
-    if file_path.exists():
-        try:
-            file_path.unlink()
-            logger.info(f"Cleaned up synthetic test data: {path}")
-        except Exception as e:
-            logger.warning(f"Failed to clean up {path}: {e}")


### PR DESCRIPTION
## Summary
- drop compatibility helpers from `tests/test_data_utils_new.py`
- remove unused legacy functions in `tests/test_data_utils.py`
- use `TestDataManager` for `sample_csv_file` and CSV path fixtures

## Testing
- `pytest tests/test_comprehensive_environments.py::TestMultiEnvironmentComparison::test_trading_env_vs_trader_env_compatibility -q`
- `pytest tests/test_td3_integration.py::TestTD3Integration::test_td3_with_trading_env_initialization -q` *(fails: fixture 'sample_csv_path' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619450ee4c832eb9a02938c7297ac8