### PR TITLE
Add Ray Tune hyperparameter search for CNN-LSTM

### DIFF
--- a/docs/ADVANCED_DATASET_DOCUMENTATION.md
+++ b/docs/ADVANCED_DATASET_DOCUMENTATION.md
@@ -310,3 +310,31 @@ The dataset is immediately ready for training the RL agent and can seamlessly in
 2. Implement live data integration using the documented patterns
 3. Monitor performance and iterate on feature engineering as needed
 4. Scale to additional symbols and markets using the provided infrastructure
+
+## CNN-LSTM Hyperparameter Optimization
+
+The `src.optimization.cnn_lstm_optimization` module uses **Ray Tune** to search
+for optimal network parameters. When Ray is not available, it automatically
+falls back to a basic grid search.
+
+Example usage:
+
+```python
+from src.optimization.cnn_lstm_optimization import optimize_cnn_lstm
+from ray import tune
+
+results = optimize_cnn_lstm(
+    features,
+    targets,
+    num_samples=20,
+    max_epochs_per_trial=30,
+    output_dir="optimization_results",
+    ray_resources_per_trial={"cpu": 2, "gpu": 1},
+    custom_search_space={"lstm_units": tune.choice([128, 256, 512])},
+)
+print(results["best_config"])
+```
+
+The `custom_search_space` and `ray_resources_per_trial` parameters let you
+override default hyperparameters and specify CPU/GPU allocation for each Ray
+trial.


### PR DESCRIPTION
## Summary
- implement Ray Tune search logic in `cnn_lstm_optimization`
- document Ray Tune usage and options in advanced dataset docs

## Testing
- `pytest tests/test_data_pipeline.py tests/test_trading_env.py tests/test_features.py -v` *(fails: test_generate_features_dimensions[50], test_generate_features_no_nan)*

------
https://chatgpt.com/codex/tasks/task_e_6861997ed580832e9915cd8c21d4c80d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced hyperparameter optimization for CNN-LSTM networks with full Ray Tune integration, including support for custom search spaces and resource allocation per trial.
  * Automatic fallback to grid search if Ray Tune is unavailable.

* **Documentation**
  * Added a new section detailing CNN-LSTM hyperparameter optimization, usage examples, and parameter explanations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->