### PR TITLE
Fail fast when ensemble sub-agent init fails

### DIFF
--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -278,5 +278,6 @@ This hybrid architecture successfully demonstrates how supervised learning can e
   - Combines SAC outputs with the optional TD3 experimental agent.
   - Designed to reduce variance and improve stability.
   - Can be extended to include additional models.
+  - Raises an error if any sub-agent fails to initialize.
 
 The agents consume observations from `TradingEnv`, take actions, and optionally contribute to ensemble decisions. This modular setup makes it straightforward to swap out or update individual components while keeping the overall pipeline intact.

--- a/src/agents/ensemble_agent.py
+++ b/src/agents/ensemble_agent.py
@@ -7,6 +7,7 @@ This agent combines multiple RL agents using advanced ensemble methods:
 - Uncertainty quantification
 - Risk-adjusted consensus
 - Meta-learning capabilities
+- Fails fast if any sub-agent cannot be initialized
 """
 
 from collections import deque
@@ -423,12 +424,9 @@ class EnsembleAgent:
                         print(f"✅ Initialized {agent_name} agent")
 
                     except Exception as e:
-                        print(f"⚠️ Failed to initialize {agent_name} agent: {e}")
-                        # Create a dummy agent placeholder
-                        self.agents[agent_name] = None
-                        self.agent_weights[agent_name] = 0.0
-                        self.agent_performance[agent_name] = []
-                        self.agent_confidence[agent_name] = 0.0
+                        raise RuntimeError(
+                            f"Failed to initialize {agent_name} agent"
+                        ) from e
 
         # Normalize weights
         self._normalize_weights()


### PR DESCRIPTION
## Summary
- raise `RuntimeError` if a sub-agent cannot be initialized
- document new fail-fast behaviour in ensemble agent section

## Testing
- `python3 -m pytest tests/test_data_pipeline.py tests/test_trading_env.py tests/test_features.py -v` *(fails: assert 50 == 24)*

------
https://chatgpt.com/codex/tasks/task_e_68619d7f1c30832ebea5ddfec17bf3ac