### PR TITLE
Add compute_reward dispatcher for reward utilities

### DIFF
--- a/src/utils/rewards.py
+++ b/src/utils/rewards.py
@@ -352,3 +352,41 @@ def get_sharpe_optimized_reward_fn() -> RewardFunction:
         transaction_cost=0.001,
         drawdown_threshold=0.1,
     )
+
+
+def compute_reward(reward_type: str, *args, **kwargs) -> float:
+    """Dispatch to the appropriate reward function.
+
+    Parameters
+    ----------
+    reward_type : str
+        Identifier of the reward function to call. Supported types include
+        ``"simple_profit"``, ``"risk_adjusted"``, ``"drawdown_penalty"``,
+        ``"sharpe"``, ``"diversification"``, ``"transaction_cost"``,
+        ``"momentum"`` and ``"custom"``.
+    *args, **kwargs
+        Arguments forwarded to the underlying reward function.
+
+    Returns
+    -------
+    float
+        Computed reward value.
+    """
+
+    dispatch_map: Dict[str, Callable[..., float]] = {
+        "simple_profit": simple_profit_reward,
+        "profit": simple_profit_reward,
+        "risk_adjusted": risk_adjusted_reward,
+        "drawdown_penalty": drawdown_penalty_reward,
+        "sharpe": sharpe_based_reward,
+        "diversification": portfolio_diversification_reward,
+        "transaction_cost": transaction_cost_penalty,
+        "momentum": momentum_reward,
+        "custom": custom_trading_reward,
+    }
+
+    if reward_type not in dispatch_map:
+        raise ValueError(f"Unknown reward type: {reward_type}")
+
+    return dispatch_map[reward_type](*args, **kwargs)
+

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from src.utils.rewards import (
+    compute_reward,
     simple_profit_reward,
     risk_adjusted_reward,
     drawdown_penalty_reward,
@@ -80,4 +81,13 @@ def test_custom_trading_reward():
         + portfolio_diversification_reward(weights, diversification_bonus=0.02)
     )
     assert np.isclose(reward, expected)
+
+
+def test_compute_reward_dispatch():
+    assert np.isclose(compute_reward("simple_profit", 100.0, 110.0), 0.1)
+    returns = np.array([0.1, 0.2, 0.3])
+    expected = risk_adjusted_reward(returns, risk_penalty=0.1)
+    assert np.isclose(
+        compute_reward("risk_adjusted", returns, risk_penalty=0.1), expected
+    )
 


### PR DESCRIPTION
## Summary
- dispatch reward calculations with `compute_reward`
- export and test the new helper

## Testing
- `pytest tests/test_rewards.py -q`
- `pytest tests/test_empty_modules.py::TestRewardsModule::test_module_is_empty -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c96bd738832ea707be58920de187