### PR TITLE
Support kwargs init for TradingEnv

### DIFF
--- a/src/envs/trading_env.py
+++ b/src/envs/trading_env.py
@@ -17,8 +17,21 @@ class TradingEnv(gym.Env):
 
     metadata = {"render.modes": ["human"]}
 
-    def __init__(self, env_cfg: dict):
-        cfg = env_cfg or {}
+    def __init__(self, env_cfg: dict | None = None, **kwargs):
+        """Initialize the environment.
+
+        Parameters can be provided either as a configuration dictionary
+        ``env_cfg`` or directly as keyword arguments. Keyword arguments will
+        override values in ``env_cfg`` when both are supplied. This preserves
+        backward compatibility with existing code that passes a single
+        configuration dictionary while allowing a more pythonic style of
+        initialization.
+        """
+
+        if env_cfg is not None and not isinstance(env_cfg, dict):
+            raise TypeError("env_cfg must be a dict if provided")
+
+        cfg = {**(env_cfg or {}), **kwargs}
         self.config = cfg  # Store config for potential cleanup access
         self.data_paths = cfg.get("dataset_paths", [])
         if isinstance(self.data_paths, str):

--- a/tests/test_trading_env.py
+++ b/tests/test_trading_env.py
@@ -22,10 +22,12 @@ def sample_csv(tmp_path):
     return str(csv)
 
 
-@pytest.fixture
-def env(sample_csv):
-    cfg = {"dataset_paths": [sample_csv], "window_size": 10}
-    return TradingEnv(cfg)
+@pytest.fixture(params=["dict", "kwargs"])
+def env(sample_csv, request):
+    if request.param == "dict":
+        cfg = {"dataset_paths": [sample_csv], "window_size": 10}
+        return TradingEnv(cfg)
+    return TradingEnv(dataset_paths=[sample_csv], window_size=10)
 
 
 def test_reset_returns_observation(env):


### PR DESCRIPTION
## Summary
- allow `TradingEnv` initialization via keyword arguments
- test both dict and keyword styles in `test_trading_env`

## Testing
- `pytest tests/test_trading_env.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861cbceeab4832eb664190d652dff5a