### PR TITLE
Add focused unit tests

### DIFF
--- a/.coveragerc_temp
+++ b/.coveragerc_temp
@@ -1,0 +1,11 @@
+[run]
+branch = True
+source = 
+    src/agents/configs.py
+    src/agents/trainer.py
+    src/data/preprocessing.py
+    src/data/features.py
+    src/optimization/model_summary.py
+
+[report]
+show_missing = True

--- a/run_focus_cov.py
+++ b/run_focus_cov.py
@@ -1,0 +1,22 @@
+import coverage
+import pytest
+import sys
+
+files = [
+    "src/agents/configs.py",
+    "src/agents/trainer.py",
+    "src/data/preprocessing.py",
+    "src/data/features.py",
+    "src/optimization/model_summary.py",
+]
+
+cov = coverage.Coverage(source=["src"])
+
+cov.start()
+result = pytest.main(["tests/focused", "-v"])
+cov.stop()
+
+cov.save()
+cov.report(include=files, show_missing=True)
+
+sys.exit(result)

--- a/tests/focused/test_dataclasses_trainer.py
+++ b/tests/focused/test_dataclasses_trainer.py
@@ -1,0 +1,47 @@
+import os
+import types
+from unittest import mock
+import pytest
+
+from src.agents.configs import EnsembleConfig
+from src.agents import trainer as trainer_module
+
+
+def test_ensemble_config_alias_and_validation():
+    cfg = EnsembleConfig(agent_configs={"sac": {"enabled": True, "config": None}})
+    assert cfg.agents == {"sac": {"enabled": True, "config": None}}
+
+
+def test_ensemble_config_empty_agents():
+    with pytest.raises(ValueError):
+        EnsembleConfig(agents={})
+
+
+def test_trainer_algorithm_case_insensitive(monkeypatch, tmp_path):
+    calls = {}
+    monkeypatch.setattr(trainer_module.ray, "is_initialized", lambda: False)
+    monkeypatch.setattr(trainer_module.ray, "init", lambda **kw: calls.setdefault("init", kw))
+    monkeypatch.setattr(trainer_module, "register_env", lambda: calls.setdefault("reg", True))
+    monkeypatch.setattr(trainer_module.ray, "shutdown", lambda: calls.setdefault("shutdown", True))
+
+    monkeypatch.setattr(trainer_module, "PPOTrainer", types.SimpleNamespace(__name__="PPOTrainer"))
+    monkeypatch.setattr(trainer_module, "DQNTrainer", types.SimpleNamespace(__name__="DQNTrainer"))
+
+    class FakeTuner:
+        def __init__(self, algo_cls, param_space=None, run_config=None):
+            calls["algo"] = algo_cls
+        def fit(self):
+            calls["fit"] = True
+
+    monkeypatch.setattr(trainer_module.tune, "Tuner", FakeTuner)
+
+    env_cfg = {}
+    model_cfg = {}
+    trainer_cfg = {"algorithm": "DQN", "num_iterations": 1, "ray_config": {}}
+
+    trainer = trainer_module.Trainer(env_cfg, model_cfg, trainer_cfg, save_dir=str(tmp_path))
+    assert trainer.algorithm == "dqn"
+    trainer.train()
+    assert calls["algo"].__name__ == "DQNTrainer"
+    assert calls.get("fit")
+    assert calls.get("shutdown")

--- a/tests/focused/test_optimization_utils.py
+++ b/tests/focused/test_optimization_utils.py
@@ -1,0 +1,22 @@
+import types
+from src.optimization import model_summary
+
+
+def test_optimal_gpu_config_no_gpu(monkeypatch):
+    monkeypatch.setattr(model_summary, "detect_gpus", lambda: {"available": False, "count": 0, "devices": []})
+    cfg = model_summary.optimal_gpu_config(model_params=1000, batch_size=4)
+    assert cfg["use_gpu"] is False
+    assert "No GPUs available" in cfg["reason"]
+
+
+def test_optimal_gpu_config_memory_constraint(monkeypatch):
+    fake_info = {
+        "available": True,
+        "count": 1,
+        "devices": [{"index": 0, "name": "GPU", "total_memory": 200, "memory_free": 50}],
+    }
+    monkeypatch.setattr(model_summary, "detect_gpus", lambda: fake_info)
+    cfg = model_summary.optimal_gpu_config(model_params=10_000_000, batch_size=64, sequence_length=100, feature_dim=30)
+    assert cfg["use_gpu"] is True
+    assert cfg["recommended_batch_size"] <= 64
+    assert cfg["mixed_precision"] or cfg["recommended_batch_size"] < 64

--- a/tests/focused/test_preprocessing_features.py
+++ b/tests/focused/test_preprocessing_features.py
@@ -1,0 +1,51 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.data.preprocessing import normalize_data, preprocess_trading_data
+from src.data.features import (
+    compute_log_returns,
+    compute_bollinger_bands,
+    compute_macd,
+)
+
+
+def test_normalize_invalid_method():
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    with pytest.raises(ValueError):
+        normalize_data(df, method="unknown")
+
+
+def test_preprocess_trading_data_pipeline():
+    dates = pd.date_range("2021-01-01", periods=10)
+    df = pd.DataFrame(
+        {
+            "time": dates,
+            "open": np.arange(10, 20, dtype=float),
+            "high": np.arange(11, 21, dtype=float),
+            "low": np.arange(9, 19, dtype=float),
+            "close": np.arange(10, 20, dtype=float),
+            "volume": np.arange(1, 11, dtype=float),
+        }
+    )
+    seq, tgt, scaler = preprocess_trading_data(
+        df, sequence_length=3, target_column="close"
+    )
+    # target column is excluded from the sequence features
+    assert seq.shape == (7, 3, df.shape[1] - 1)
+    assert tgt.shape == (7, 1)
+    assert hasattr(scaler, "transform")
+
+
+def test_feature_generators_basic():
+    data = pd.DataFrame({"close": np.arange(1, 6, dtype=float)})
+    df = compute_log_returns(data.copy())
+    assert "log_return" in df.columns
+
+    series_res = compute_log_returns(data["close"])
+    assert len(series_res) == len(data)
+
+    upper, mid, lower = compute_bollinger_bands(data["close"], timeperiod=3)
+    assert upper.isna().iloc[:2].all()
+    macd_df = compute_macd(data.copy(), price_col="close")
+    assert {"macd_line", "macd_signal", "macd_hist"}.issubset(macd_df.columns)


### PR DESCRIPTION
## Summary
- add focused tests for agent configs and trainer logic
- test data preprocessing and feature generators
- test optimization utilities
- include helper script and coverage config for focused runs

## Testing
- `pytest tests/focused -v --cov=src --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_6861ce7456a8832e959207a24a580d60