### PR TITLE
Add conftest_extra as pytest plugin

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["tests.conftest_extra"]


### PR DESCRIPTION
## Summary
- load `tests.conftest_extra` in `tests/__init__.py` to expose shared fixtures for every test

## Testing
- `pytest tests/test_empty_modules.py::TestEmptyModules::test_cnn_lstm_module_exists -q`

------
https://chatgpt.com/codex/tasks/task_e_6861dfca71ec832ebb028c2c0789df66