### PR TITLE
Add simple backtester loop with slippage and latency

### DIFF
--- a/src/eval/__init__.py
+++ b/src/eval/__init__.py
@@ -5,7 +5,8 @@ illustrates the interface for an event-driven backtesting engine.
 """
 
 from __future__ import annotations
-from typing import Any
+
+from typing import Any, Callable, List, Sequence
 
 
 class Backtester:
@@ -26,7 +27,15 @@ class Backtester:
     0.5
     """
 
-    def run_backtest(self, prices: Any, policy: Any) -> Any:
+    def __init__(self, slippage_pct: float = 0.0, latency_seconds: float = 0.0) -> None:
+        """Initialize backtester with slippage and latency models."""
+
+        self.slippage_pct = slippage_pct
+        self.latency_seconds = latency_seconds
+
+    def run_backtest(
+        self, prices: Sequence[float], policy: Callable[[float], Any]
+    ) -> List[dict]:
         """Execute a backtest over ``prices`` using ``policy``.
 
         Parameters
@@ -38,12 +47,18 @@ class Backtester:
 
         Returns
         -------
-        Any
-            Placeholder backtest results.  Currently returns ``None``.
+        list of dict
+            List of executed actions with adjusted price and delay.
         """
 
-        # TODO: implement event-driven backtesting
-        return None
+        results = []
+        for price in prices:
+            action = policy(price)
+            executed_price = self.apply_slippage(price)
+            delay = self.apply_latency(0.0)
+            results.append({"price": executed_price, "action": action, "delay": delay})
+
+        return results
 
     def apply_slippage(self, price: float) -> float:
         """Apply a slippage model to ``price``.
@@ -56,11 +71,10 @@ class Backtester:
         Returns
         -------
         float
-            Adjusted trade price.  Currently returned unchanged.
+            Adjusted trade price after slippage.
         """
 
-        # TODO: implement slippage logic
-        return price
+        return price * (1 + self.slippage_pct)
 
     def apply_latency(self, delay: float) -> float:
         """Apply a latency model to ``delay``.
@@ -73,8 +87,7 @@ class Backtester:
         Returns
         -------
         float
-            Adjusted delay after latency effects.  Currently returned unchanged.
+            Adjusted delay after latency effects.
         """
 
-        # TODO: implement latency logic
-        return delay
+        return delay + self.latency_seconds

--- a/tests/test_backtester_stub.py
+++ b/tests/test_backtester_stub.py
@@ -1,11 +1,30 @@
+import pytest
+
 from src.eval import Backtester
 
 
-def test_backtester_stub_methods():
+def test_backtester_event_loop_without_adjustments():
     bt = Backtester()
 
-    result = bt.run_backtest(prices=[1, 2, 3], policy=lambda p: "hold")
-    assert result is None
+    policy = lambda p: "buy" if p > 1 else "sell"
+    result = bt.run_backtest(prices=[1, 2, 3], policy=policy)
 
-    assert bt.apply_slippage(100.0) == 100.0
-    assert bt.apply_latency(0.1) == 0.1
+    assert result == [
+        {"price": 1, "action": "sell", "delay": 0.0},
+        {"price": 2, "action": "buy", "delay": 0.0},
+        {"price": 3, "action": "buy", "delay": 0.0},
+    ]
+
+
+def test_backtester_with_slippage_and_latency():
+    bt = Backtester(slippage_pct=0.1, latency_seconds=0.5)
+
+    result = bt.run_backtest(prices=[10, 20], policy=lambda p: "hold")
+
+    assert result == [
+        {"price": 11.0, "action": "hold", "delay": 0.5},
+        {"price": 22.0, "action": "hold", "delay": 0.5},
+    ]
+
+    assert bt.apply_slippage(100.0) == pytest.approx(110.0)
+    assert bt.apply_latency(0.0) == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- flesh out Backtester with event loop
- implement basic slippage and latency models
- test backtester behavior with and without adjustments

## Testing
- `pytest tests/test_backtester_stub.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f97b288c832e9cabdd027aed453a