### PR TITLE
Expose NLP sentiment scoring helpers

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -159,6 +159,15 @@ This section provides detailed API documentation for all modules and classes.
    :show-inheritance:
 ```
 
+## NLP Utilities
+
+```{eval-rst}
+.. automodule:: src.nlp
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
 ## Optimization
 
 ### CNN-LSTM Optimization

--- a/src/nlp/__init__.py
+++ b/src/nlp/__init__.py
@@ -1,4 +1,88 @@
 """Natural language processing utilities.
 
-TODO: expose sentiment and risk scoring APIs for use in the data pipeline.
+This module exposes simple wrappers around the sentiment providers defined in
+``src.data.sentiment`` so that other parts of the code base (e.g. the data
+pipeline) can obtain sentiment scores without dealing with the provider classes
+directly.
+
+Two helper functions are provided for scoring news and social media sentiment
+separately.  :func:`get_sentiment_scores` aggregates these and returns a
+convenient dictionary that can be easily attached to a dataframe of market
+features.
 """
+
+from __future__ import annotations
+
+import datetime
+from typing import Dict
+
+from src.data.sentiment import (
+    NewsSentimentProvider,
+    SentimentData,
+    SocialSentimentProvider,
+)
+
+
+def _aggregate_sentiment(data: list[SentimentData], days_back: int) -> float:
+    """Aggregate sentiment scores with magnitude and recency weighting."""
+    if not data:
+        return 0.0
+
+    now = datetime.datetime.now()
+    total_score = 0.0
+    total_weight = 0.0
+
+    for d in data:
+        hours_old = (now - d.timestamp).total_seconds() / 3600
+        recency_weight = max(0.1, 1.0 - (hours_old / (days_back * 24)))
+        weight = d.magnitude * recency_weight
+        total_score += d.score * weight
+        total_weight += weight
+
+    return total_score / total_weight if total_weight > 0 else 0.0
+
+
+def score_news_sentiment(symbol: str, days_back: int = 1) -> float:
+    """Return the aggregated news sentiment score for ``symbol``."""
+
+    provider = NewsSentimentProvider()
+    data = provider.fetch_sentiment(symbol, days_back)
+    return _aggregate_sentiment(data, days_back)
+
+
+def score_social_sentiment(symbol: str, days_back: int = 1) -> float:
+    """Return the aggregated social media sentiment score for ``symbol``."""
+
+    provider = SocialSentimentProvider()
+    data = provider.fetch_sentiment(symbol, days_back)
+    return _aggregate_sentiment(data, days_back)
+
+
+def get_sentiment_scores(symbol: str, days_back: int = 1) -> Dict[str, float]:
+    """Return news, social and overall sentiment scores for ``symbol``.
+
+    The overall score is computed from all available sentiment data using the
+    same weighting scheme as the individual scores.
+    """
+
+    news_data = NewsSentimentProvider().fetch_sentiment(symbol, days_back)
+    social_data = SocialSentimentProvider().fetch_sentiment(symbol, days_back)
+
+    news_score = _aggregate_sentiment(news_data, days_back)
+    social_score = _aggregate_sentiment(social_data, days_back)
+
+    combined = news_data + social_data
+    overall = _aggregate_sentiment(combined, days_back)
+
+    return {
+        "news_sentiment": news_score,
+        "social_sentiment": social_score,
+        "aggregate_sentiment": overall,
+    }
+
+
+__all__ = [
+    "score_news_sentiment",
+    "score_social_sentiment",
+    "get_sentiment_scores",
+]

--- a/tests/test_nlp_sentiment.py
+++ b/tests/test_nlp_sentiment.py
@@ -1,0 +1,67 @@
+import datetime
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from src.data.features import generate_features
+from src.data.sentiment import SentimentData
+from src.data.synthetic import generate_gbm_prices
+from src.nlp import (
+    get_sentiment_scores,
+    score_news_sentiment,
+    score_social_sentiment,
+)
+
+
+@pytest.fixture
+def sample_sentiment():
+    now = datetime.datetime.now()
+    return [
+        SentimentData("AAPL", 0.6, 0.8, now, "news"),
+        SentimentData("AAPL", 0.2, 0.5, now - datetime.timedelta(hours=1), "news"),
+    ]
+
+
+def test_score_news_sentiment(monkeypatch, sample_sentiment):
+    with patch(
+        "src.data.sentiment.NewsSentimentProvider.fetch_sentiment",
+        return_value=sample_sentiment,
+    ):
+        score = score_news_sentiment("AAPL")
+        assert isinstance(score, float)
+        assert score > 0
+
+
+def test_score_social_sentiment(monkeypatch, sample_sentiment):
+    with patch(
+        "src.data.sentiment.SocialSentimentProvider.fetch_sentiment",
+        return_value=sample_sentiment,
+    ):
+        score = score_social_sentiment("AAPL")
+        assert isinstance(score, float)
+        assert score > 0
+
+
+def test_get_sentiment_scores_pipeline_usage(monkeypatch, sample_sentiment):
+    with (
+        patch(
+            "src.data.sentiment.NewsSentimentProvider.fetch_sentiment",
+            return_value=sample_sentiment,
+        ),
+        patch(
+            "src.data.sentiment.SocialSentimentProvider.fetch_sentiment",
+            return_value=sample_sentiment,
+        ),
+    ):
+        scores = get_sentiment_scores("AAPL")
+        assert set(scores) == {
+            "news_sentiment",
+            "social_sentiment",
+            "aggregate_sentiment",
+        }
+        df = generate_gbm_prices(n_days=5)
+        df["symbol"] = "AAPL"
+        feats = generate_features(df)
+        feats["sentiment"] = scores["aggregate_sentiment"]
+        assert "sentiment" in feats.columns


### PR DESCRIPTION
## Summary
- implement sentiment scoring helpers in `src/nlp`
- document new NLP module in API docs
- add tests demonstrating usage from the data pipeline

## Testing
- `pytest tests/test_nlp_sentiment.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f97d91d4832eaaae51e47f0f8dca