### PR TITLE
Fix runtime imports and bare excepts

### DIFF
--- a/build_advanced_dataset.py
+++ b/build_advanced_dataset.py
@@ -33,10 +33,10 @@ from tqdm import tqdm
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent))
 
-from src.data.features import generate_features
-from src.data.forex_sentiment import get_forex_sentiment
-from src.data.historical import fetch_historical_data
-from src.data.synthetic import generate_gbm_prices
+from src.data.features import generate_features  # noqa: E402
+from src.data.forex_sentiment import get_forex_sentiment  # noqa: E402
+from src.data.historical import fetch_historical_data  # noqa: E402
+from src.data.synthetic import generate_gbm_prices  # noqa: E402
 
 # Configure logging
 logging.basicConfig(

--- a/build_datasets.py
+++ b/build_datasets.py
@@ -39,7 +39,7 @@ root = Path(__file__).parent
 sys.path.insert(0, str(root))
 
 # Synthetic data generator
-from generate_sample_data import (
+from generate_sample_data import (  # noqa: E402
     add_sentiment_features,
     add_technical_indicators,
     generate_labels,
@@ -47,7 +47,7 @@ from generate_sample_data import (
 )
 
 # Historical data fetcher
-from src.data.historical import fetch_historical_data
+from src.data.historical import fetch_historical_data  # noqa: E402
 
 
 def generate_synthetic(symbols, days, volatility, scenarios_per_symbol):

--- a/build_production_dataset.py
+++ b/build_production_dataset.py
@@ -28,9 +28,11 @@ import yfinance as yf
 # Add src to path for imports
 sys.path.append(str(Path(__file__).parent / "src"))
 
-from src.data.features import generate_features
-from src.data.sentiment import get_sentiment_score
-from src.data.synthetic import fetch_synthetic_data, generate_gbm_prices
+from src.data.features import generate_features  # noqa: E402
+from src.data.sentiment import get_sentiment_score  # noqa: E402
+from src.data.synthetic import fetch_synthetic_data, generate_gbm_prices  # noqa: E402
+from src.envs.trader_env import TraderEnv  # noqa: E402
+import traceback  # noqa: E402
 
 # Suppress warnings for cleaner output
 warnings.filterwarnings("ignore")
@@ -207,7 +209,7 @@ class AdvancedDatasetBuilder:
                             sentiment_score = get_sentiment_score(symbol, days_back=1)
                             enhanced_data["sentiment"] = sentiment_score
                             enhanced_data["sentiment_magnitude"] = abs(sentiment_score)
-                        except:
+                        except Exception:
                             enhanced_data["sentiment"] = 0.0
                             enhanced_data["sentiment_magnitude"] = 0.0
                     else:
@@ -485,8 +487,6 @@ def main():
         # Test compatibility with training environment
         print("\n🧪 Testing compatibility with training environment...")
         try:
-            from src.envs.trader_env import TraderEnv
-
             env = TraderEnv(
                 [file_paths["training_data"]], window_size=10, initial_balance=10000
             )
@@ -501,8 +501,6 @@ def main():
 
     except Exception as e:
         print(f"❌ Dataset building failed: {e}")
-        import traceback
-
         traceback.print_exc()
         return None
 

--- a/run_comprehensive_tests.py
+++ b/run_comprehensive_tests.py
@@ -447,7 +447,7 @@ class ComprehensiveTestRunner:
             duration = f"{result['duration']:.2f}s" if "duration" in result else "N/A"
             md += f"| {test_name.title()} | {status} | {duration} |\n"
 
-        md += f"""
+        md += """
 ## Coverage
 
 Coverage reports are available in:
@@ -507,7 +507,7 @@ Coverage reports are available in:
         try:
             subprocess.run(["ray", "stop"], capture_output=True, timeout=10)
             print("🛑 Ray cluster stopped")
-        except:
+        except Exception:
             pass
 
     def cleanup(self) -> None:
@@ -530,7 +530,7 @@ Coverage reports are available in:
                         file.unlink()
                     elif file.is_dir():
                         shutil.rmtree(file)
-                except:
+                except Exception:
                     pass
 
         print("✅ Cleanup completed")

--- a/tests/conftest_extra.py
+++ b/tests/conftest_extra.py
@@ -24,12 +24,12 @@ import pytest
 import torch
 import yaml
 
+# Import test utilities
+from tests.test_data_utils import TestDataManager, get_dynamic_test_config
+
 # Configure test logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-# Import test utilities
-from tests.test_data_utils import TestDataManager, get_dynamic_test_config
 
 # Legacy compatibility import
 try:
@@ -420,7 +420,7 @@ def ray_cluster():
         try:
             if ray.is_initialized():
                 ray.shutdown()
-        except:
+        except Exception:
             pass
 
 
@@ -473,7 +473,7 @@ def cleanup_temp_files():
         import tempfile
 
         temp_files_before = set(os.listdir(tempfile.gettempdir()))
-    except:
+    except Exception:
         pass
 
     yield
@@ -491,9 +491,9 @@ def cleanup_temp_files():
                         file_path.unlink()
                     elif file_path.is_dir():
                         shutil.rmtree(file_path, ignore_errors=True)
-                except:
+                except Exception:
                     pass
-    except:
+    except Exception:
         pass
 
 

--- a/tests/test_environment_comprehensive.py
+++ b/tests/test_environment_comprehensive.py
@@ -438,7 +438,7 @@ class TestEnvironmentIntegration:
                             action = np.clip(
                                 action, env.action_space.low, env.action_space.high
                             )
-                except:
+                except Exception:
                     pass  # Some spaces might not support contains check
 
             # Take step with agent action


### PR DESCRIPTION
## Summary
- move runtime imports to module level
- use explicit exception types
- clean up E402 warnings with `noqa`
- fix flake8 F541 error

## Testing
- `flake8 build_advanced_dataset.py build_datasets.py build_production_dataset.py run_comprehensive_tests.py tests/conftest_extra.py tests/test_environment_comprehensive.py | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_6861f97e5f80832ebdc012cca06a2960