### PR TITLE
Remove unused test_ray_fix

### DIFF
--- a/scripts/comprehensive_cleanup.py
+++ b/scripts/comprehensive_cleanup.py
@@ -28,7 +28,6 @@ class TradingRLCleaner:
         redundant_files = [
             # Root level test files (should be in tests/ directory)
             "test_fix.py",
-            "test_ray_fix.py",
             "test_ray_compatibility.py",
             "minimal_test.py",
             "quick_integration_test.py",


### PR DESCRIPTION
## Summary
- drop the empty `test_ray_fix.py`
- update the cleanup script to stop referencing the old file

## Testing
- `pytest --collect-only --no-cov -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f97f423c832eac6320b6d81009e3