### PR TITLE
docs: add educational-use disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,14 @@ This is a research-focused project with production-ready implementations. See [C
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
+## ⚠️ Important Disclaimer
+
+This project is provided **for educational and research purposes only**. The code
+and examples are **not financial advice**. Always validate strategies thoroughly
+and begin with **paper trading** before using real capital. Trading carries
+substantial risk—never risk more than you can afford to lose and consider
+consulting a qualified financial professional.
+
 ---
 
 **🎯 Status**: Environment testing framework complete, core functionality validated | **🧪 Tests**: ~733 defined | **📊 Data**: sample datasets provided; large historical datasets optional. Metrics are illustrative.

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,3 +115,5 @@ jupyter lab
 ---
 
 **📋 Note**: This documentation reflects the current production-ready state of the hybrid CNN+LSTM + RL trading system. All guides and tools have been validated in the production environment with comprehensive test coverage.
+
+For financial risk guidance, see the [Important Disclaimer](../README.md#important-disclaimer) in the project root.


### PR DESCRIPTION
## Summary
- caution about educational use only in the project README
- link to this disclaimer from the docs README

## Testing
- `sh test-fast.sh` *(fails: `/opt/conda/bin/python3.12` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686212f92518832eb889efa89f882b70