### PR TITLE
Switch to pandas-ta indicators

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -14,4 +14,8 @@ python-dotenv>=0.20.0,<1.1.0  # Environment variables
 pytest>=7.0.0,<8.0.0     # 5MB - Unit testing
 faker>=13.0.0,<25.0.0    # 10MB - Test data generation
 
+# Technical analysis
+pandas-ta>=0.3.14b0
+ta-lib>=0.4.28
+
 # Total: ~111MB - Fast installation and imports

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -17,6 +17,8 @@ flake8-docstrings>=1.7.0
 flake8-bugbear>=23.12.2
 flake8-comprehensions>=3.14.0
 flake8-simplify>=0.21.0
+pandas-ta>=0.3.14b0
+ta-lib>=0.4.28
 
 # Type checking
 mypy>=1.8.0

--- a/requirements-finrl.txt
+++ b/requirements-finrl.txt
@@ -32,6 +32,7 @@ pyfolio-reloaded>=0.9.5
 
 # Data Processing & Technical Analysis
 ta-lib>=0.4.26
+pandas-ta>=0.3.14b0
 stockstats>=0.5.0
 finta>=1.3.0
 

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -10,6 +10,8 @@ ray[rllib]>=2.31.0,<2.47.0  # 500MB - Distributed RL training
 # Market data and analysis
 yfinance>=0.2.0,<0.3.0       # 10MB - Financial data
 ta>=0.10.0,<0.11.0           # 5MB - Technical analysis indicators
+pandas-ta>=0.3.14b0
+ta-lib>=0.4.28
 
 # Additional dependencies
 datasets

--- a/requirements-messaging.txt
+++ b/requirements-messaging.txt
@@ -9,3 +9,5 @@ orjson>=3.9.0
 
 # Async utilities
 aiofiles>=23.0.0
+pandas-ta>=0.3.14b0
+ta-lib>=0.4.28

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -17,6 +17,8 @@ yfinance>=0.2.0,<0.3.0     # Financial data
 
 # Technical indicators
 ta>=0.10.0,<0.11.0         # Technical analysis
+pandas-ta>=0.3.14b0
+ta-lib>=0.4.28
 
 # Testing
 pytest>=7.4.0              # Unit testing (updated for compatibility)

--- a/requirements-ml.txt
+++ b/requirements-ml.txt
@@ -7,5 +7,7 @@
 # Machine learning frameworks
 torch>=1.12.0,<2.4.0     # 2GB - PyTorch for neural networks
 gymnasium>=0.28.0,<0.30.0  # 10MB - RL environments (lightweight)
+pandas-ta>=0.3.14b0
+ta-lib>=0.4.28
 
 # Total: ~2.1GB - ML development ready

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -37,6 +37,7 @@ empyrical>=0.5.5            # Statistical risk metrics
 # Technical Analysis - Professional Grade
 # ========================================
 ta-lib>=0.4.25              # Industry standard technical analysis
+pandas-ta>=0.3.14b0
 ta>=0.10.2                  # Additional technical indicators
 finta>=1.3                  # Financial technical analysis
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -17,6 +17,8 @@ faker>=19.0.0  # Fake data generation
 responses>=0.23.0  # HTTP mocking
 freezegun>=1.2.0  # Time mocking
 testfixtures>=7.2.0  # Test fixtures
+pandas-ta>=0.3.14b0
+ta-lib>=0.4.28
 
 # Performance testing
 memory-profiler>=0.61.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,8 @@ gymnasium>=0.28.0,<0.30.0  # RL environments
 # Market data & Technical Analysis
 yfinance>=0.2.0,<0.3.0     # Financial data
 ta>=0.10.0,<0.11.0         # Technical indicators
+pandas-ta>=0.3.14b0
+ta-lib>=0.4.28
 
 # Testing
 pytest>=7.4.0              # Unit testing (updated for compatibility)


### PR DESCRIPTION
## Summary
- use pandas-ta for indicator computation
- fallback to TA-Lib where available
- simplify candle pattern detection
- drop warmup rows when generating features
- include `pandas-ta` and `ta-lib` in requirements lists

## Testing
- `pytest tests/test_feature_pipeline.py::test_generate_features_with_basic_candles -q`
- `pytest tests/test_data_ingestion_pipeline.py::test_generate_features_with_missing_values -q`

------
https://chatgpt.com/codex/tasks/task_e_6862aba58800832ea89c43621de2413d