### PR TITLE
Add FinRL dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,3 +55,4 @@ alpaca-py>=0.4.0
 alpaca-trade-api>=2.3.0
 ccxt>=1.66.32
 stockstats>=0.4.0
+TA-Lib>=0.4.28        # Required by FinRL & local tests (`import talib`)

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,10 @@ requests>=2.28.0,<3.0.0  # HTTP requests for sentiment and data fetching
 beautifulsoup4>=4.11.0,<5.0.0  # HTML parsing for sentiment scraping
 psutil>=5.9.0,<6.0
 backtesting>=0.6.4
+
+# FinRL & related dependencies
+finrl>=0.3.7
+alpaca-py>=0.4.0
+alpaca-trade-api>=2.3.0
+ccxt>=1.66.32
+stockstats>=0.4.0


### PR DESCRIPTION
## Summary
- ensure FinRL environment requirements are installed

## Testing
- `pytest tests/test_industry_standards.py::TestFinRLIntegration::test_finrl_environment_creation -vv -s` *(fails: ModuleNotFoundError: No module named 'talib')*

------
https://chatgpt.com/codex/tasks/task_e_6865e849a4cc832ead2736f384fde43c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new dependencies for algorithmic trading, market data access, and technical analysis, including FinRL, Alpaca, CCXT, and Stockstats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->