### PR TITLE
Switch backtester to Backtrader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ known_first_party = ["src"]
 known_third_party = [
     "numpy", "pandas", "torch", "ray", "gymnasium", "yfinance",
     "ta", "scipy", "matplotlib", "seaborn", "plotly", "pytest",
-    "pyyaml", "tqdm", "wandb", "optuna", "sklearn", "backtesting"
+    "pyyaml", "tqdm", "wandb", "optuna", "sklearn", "backtrader"
 ]
 sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
 skip_glob = ["*/__init__.py"]

--- a/requirements.in
+++ b/requirements.in
@@ -47,7 +47,7 @@ empyrical>=0.5.3
 requests>=2.28.0,<3.0.0  # HTTP requests for sentiment and data fetching
 beautifulsoup4>=4.11.0,<5.0.0  # HTML parsing for sentiment scraping
 psutil>=5.9.0,<6.0
-backtesting>=0.6.4
+backtrader>=1.9.78
 riskfolio-lib>=7.0.1
 
 # FinRL & related dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ typer[all]>=0.9.0
 requests>=2.28.0,<3.0.0  # HTTP requests for sentiment and data fetching
 beautifulsoup4>=4.11.0,<5.0.0  # HTML parsing for sentiment scraping
 psutil>=5.9.0,<6.0
-backtesting>=0.6.4
+backtrader>=1.9.78
 riskfolio-lib>=7.0.1
 
 # FinRL & related dependencies

--- a/src/backtesting/__init__.py
+++ b/src/backtesting/__init__.py
@@ -1,4 +1,4 @@
-"""Backtesting utilities using backtesting.py."""
+"""Backtesting utilities built on :mod:`backtrader`."""
 
 from .backtester import Backtester
 

--- a/src/backtesting/backtester.py
+++ b/src/backtesting/backtester.py
@@ -57,7 +57,7 @@ class Backtester:
                 price_obs = (
                     self.data.close[-self.latency - 1]
                     if self.latency
-                    else self.data.close[0]
+                    else self.data.close[-1]
                 )
                 action = self.policy(price_obs)
                 if action == "buy":

--- a/src/backtesting/backtester.py
+++ b/src/backtesting/backtester.py
@@ -3,18 +3,20 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Callable
 
-from backtesting import Backtest, Strategy
+import backtrader as bt
 import pandas as pd
 
 
 class Backtester:
-    """Thin wrapper around :class:`backtesting.Backtest` with slippage and latency."""
+    """Simple Backtrader-based wrapper supporting slippage and latency."""
 
     def __init__(self, slippage_pct: float = 0.0, latency_seconds: float = 0.0) -> None:
         self.slippage_pct = slippage_pct
         self.latency_seconds = latency_seconds
 
-    def run_backtest(self, prices: Sequence[float], policy: Callable[[float], str]):
+    def run_backtest(
+        self, prices: Sequence[float], policy: Callable[[float], str]
+    ) -> pd.Series:
         """Run a backtest over a sequence of prices using ``policy``.
 
         Parameters
@@ -26,50 +28,56 @@ class Backtester:
 
         Returns
         -------
-        backtesting._stats._Stats
-            Results returned by :meth:`backtesting.Backtest.run`.
+        pandas.Series
+            Series containing a ``"Return [%]"`` key with total return.
         """
 
         df = pd.DataFrame(
             {
-                "Open": prices,
-                "High": prices,
-                "Low": prices,
-                "Close": prices,
+                "open": prices,
+                "high": prices,
+                "low": prices,
+                "close": prices,
             },
-            index=pd.RangeIndex(len(prices)),
+            index=pd.date_range("2000-01-01", periods=len(prices)),
         )
 
         latency_steps = int(self.latency_seconds)
-        slippage = self.slippage_pct
-        policy_fn = policy
 
-        class PolicyStrategy(Strategy):
-            def init(self):
-                pass
+        class PolicyStrategy(bt.Strategy):
+            params = dict(policy=None, latency=0)
+
+            def __init__(self):
+                self.policy = self.p.policy
+                self.latency = self.p.latency
 
             def next(self):
-                if latency_steps and self.i - latency_steps < 0:
+                if len(self.data) <= self.latency:
                     return
                 price_obs = (
-                    self.data.Close[-latency_steps - 1]
-                    if latency_steps
-                    else self.data.Close[-1]
+                    self.data.close[-self.latency - 1]
+                    if self.latency
+                    else self.data.close[0]
                 )
-                action = policy_fn(price_obs)
+                action = self.policy(price_obs)
                 if action == "buy":
                     self.buy()
                 elif action == "sell":
                     self.sell()
 
-        bt = Backtest(df, PolicyStrategy, commission=slippage)
-        stats = bt.run()
-        return pd.Series(stats._stats)
+        cerebro = bt.Cerebro()
+        cerebro.adddata(bt.feeds.PandasData(dataname=df))
+        cerebro.addstrategy(PolicyStrategy, policy=policy, latency=latency_steps)
+        cerebro.broker.set_slippage_perc(self.slippage_pct)
+        cerebro.broker.setcommission(commission=self.slippage_pct)
+        if latency_steps == 0:
+            cerebro.broker.set_coc(True)
+        else:
+            cerebro.broker.set_coc(False)
 
-    def apply_slippage(self, price: float) -> float:
-        """Apply the configured slippage percentage to ``price``."""
-        return price * (1 + self.slippage_pct)
-
-    def apply_latency(self, delay: float) -> float:
-        """Apply the configured latency to ``delay``."""
-        return delay + self.latency_seconds
+        initial_cash = 100.0
+        cerebro.broker.setcash(initial_cash)
+        cerebro.run()
+        final_value = cerebro.broker.getvalue()
+        return_pct = (final_value - initial_cash) / initial_cash * 100
+        return pd.Series({"Return [%]": return_pct})

--- a/src/backtesting/backtester.py
+++ b/src/backtesting/backtester.py
@@ -42,7 +42,7 @@ class Backtester:
             index=pd.date_range("2000-01-01", periods=len(prices)),
         )
 
-        latency_steps = int(self.latency_seconds)
+        latency_steps = round(self.latency_seconds)
 
         class PolicyStrategy(bt.Strategy):
             params = dict(policy=None, latency=0)

--- a/tests/test_backtester_wrapper.py
+++ b/tests/test_backtester_wrapper.py
@@ -12,6 +12,14 @@ def test_backtester_runs_basic_strategy():
 
 
 def test_backtester_slippage_and_latency():
-    bt = Backtester(slippage_pct=0.1, latency_seconds=1)
-    assert bt.apply_slippage(100.0) == pytest.approx(110.0)
-    assert bt.apply_latency(0.0) == pytest.approx(1.0)
+    bt_no_slip = Backtester()
+    res_no_slip = bt_no_slip.run_backtest(prices=[1, 2, 3], policy=lambda p: "buy")
+
+    bt_slip = Backtester(slippage_pct=0.1)
+    res_slip = bt_slip.run_backtest(prices=[1, 2, 3], policy=lambda p: "buy")
+
+    bt_lat = Backtester(latency_seconds=1)
+    res_lat = bt_lat.run_backtest(prices=[1, 2, 3, 4], policy=lambda p: "buy")
+
+    assert res_slip["Return [%]"] < res_no_slip["Return [%]"]
+    assert isinstance(res_lat, pd.Series)


### PR DESCRIPTION
## Summary
- use Backtrader instead of backtesting.py
- remove manual slippage/latency helpers
- update tests for Backtrader wrapper
- update dependencies

## Testing
- `pytest -q tests/test_backtester_wrapper.py`

------
https://chatgpt.com/codex/tasks/task_e_6869a7193cfc832ebf7064d81acf309e