### PR TITLE
Use native nats context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ python finrl_data_loader.py --config configs/finrl_real_data.yaml
 python src/train_finrl_agent.py --agent sac --data sample --backtesting realistic
 ```
 
+### Messaging Example
+
+```python
+import asyncio
+from messaging import connect
+
+
+async def main():
+    async with connect(servers=["nats://localhost:4222"]) as nc:
+        await nc.publish("trades.buy", b"{\"symbol\": \"AAPL\"}")
+        await nc.subscribe("trades.*", cb=lambda msg: print(msg.data))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
 ---
 
 ## 🔍 Current Status

--- a/src/messaging/__init__.py
+++ b/src/messaging/__init__.py
@@ -1,5 +1,6 @@
 """Messaging utilities for NATS."""
 
-from .nats_utils import connect, disconnect, publish, subscribe
+from nats import connect
+from .nats_utils import NATS
 
-__all__ = ["connect", "disconnect", "publish", "subscribe"]
+__all__ = ["connect", "NATS"]

--- a/src/messaging/nats_utils.py
+++ b/src/messaging/nats_utils.py
@@ -1,76 +1,18 @@
-"""NATS messaging utilities.
+"""Minimal utilities for working with the NATS client.
 
-This module provides lightweight helper functions for connecting to a NATS
-server and publishing/subscribing to subjects. It uses the asynchronous NATS
-client directly without an additional wrapper class.
+The previous iteration of this module exposed ``connect``/``disconnect`` as
+custom wrappers along with ``publish`` and ``subscribe`` helpers.  The NATS
+client now natively supports an asynchronous context manager via
+``nats.connect``.  Call sites should use::
+
+    async with nats.connect(servers=["nats://localhost:4222"]) as nc:
+        await nc.publish("topic", b"hello")
+
+``nc.publish`` and ``nc.subscribe`` should be invoked directly without wrapper
+functions.  This module only re-exports the ``NATS`` client class for typing
+purposes.
 """
-
-from __future__ import annotations
-
-from collections.abc import Awaitable
-from datetime import datetime
-import json
-import logging
-from typing import Any, Callable, Optional
 
 from nats.aio.client import Client as NATS
 
-logger = logging.getLogger(__name__)
-
-
-async def connect(nats_url: str = "nats://localhost:4222") -> NATS:
-    """Create and connect a NATS client.
-
-    Args:
-        nats_url: URL of the NATS server.
-
-    Returns:
-        Connected ``NATS`` client instance.
-    """
-
-    nc = NATS()
-    await nc.connect(
-        servers=[nats_url],
-        connect_timeout=10,
-        max_reconnect_attempts=5,
-        reconnect_time_wait=2,
-    )
-    logger.info(f"Connected to NATS at {nats_url}")
-    return nc
-
-
-async def disconnect(nc: NATS) -> None:
-    """Gracefully close the NATS connection."""
-    await nc.close()
-    logger.info("Disconnected from NATS")
-
-
-async def publish(nc: NATS, subject: str, data: dict[str, Any]) -> None:
-    """Publish a JSON-encoded message to a subject."""
-    data = (
-        data.copy()
-    )  # Create a shallow copy to avoid mutating the caller's dictionary
-    if "timestamp" not in data:
-        data["timestamp"] = datetime.utcnow().isoformat()
-    message = json.dumps(data).encode()
-    await nc.publish(subject, message)
-    logger.debug(f"Published to {subject}: {data}")
-
-
-async def subscribe(
-    nc: NATS,
-    subject: str,
-    callback: Callable[[dict[str, Any]], Awaitable[None]],
-    queue: str | None = None,
-) -> None:
-    """Subscribe to a subject and process messages with ``callback``."""
-
-    async def handler(msg):
-        try:
-            payload = json.loads(msg.data.decode())
-            await callback(payload)
-        except Exception as exc:  # pragma: no cover - runtime safety
-            logger.error(f"Error in NATS handler: {exc}")
-
-    await nc.subscribe(subject, cb=handler, queue=queue)
-    logger.info(f"Subscribed to {subject}")
+__all__ = ["NATS"]


### PR DESCRIPTION
## Summary
- update README with NATS messaging example
- simplify `messaging` package to re-export `nats.connect`
- remove custom publish/subscribe helpers

## Testing
- `flake8 src/messaging/nats_utils.py src/messaging/__init__.py`
- `pytest tests/test_empty_modules.py::TestEmptyModules::test_cnn_lstm_module_exists -q`


------
https://chatgpt.com/codex/tasks/task_e_6869aa7364e4832eba6164b9e39f10c7