### PR TITLE
Switch to Optuna hyperparameter tuning

### DIFF
--- a/docs/ADVANCED_DATASET_DOCUMENTATION.md
+++ b/docs/ADVANCED_DATASET_DOCUMENTATION.md
@@ -318,9 +318,9 @@ The dataset is immediately ready for training the RL agent and can seamlessly in
 
 ## CNN-LSTM Hyperparameter Optimization
 
-The `src.optimization.cnn_lstm_optimization` module uses **Ray Tune** to search
-for optimal network parameters. When Ray is not available, it automatically
-falls back to a basic grid search.
+The `src.optimization.cnn_lstm_optimization` module uses **Optuna** for
+hyperparameter search. When Ray Tune is available it integrates with
+`OptunaSearch`; otherwise it runs a standalone Optuna study.
 
 Example usage:
 

--- a/tests/test_streamlined_optimization.py
+++ b/tests/test_streamlined_optimization.py
@@ -28,17 +28,18 @@ def test_optimization():
             features=features, targets=targets, num_samples=2, max_epochs_per_trial=5
         )
 
+        assert results.get("method") == "optuna"
         print("✅ Optimization test successful!")
         print(f"   • Best score: {results['best_score']:.4f}")
         print(f"   • Best config: {results['best_config']}")
 
-        return True
+        assert isinstance(results["best_score"], float)
+        assert isinstance(results["best_config"], dict)
 
     except Exception as e:
         print(f"❌ Test failed: {e}")
-        return False
+        raise
 
 
 if __name__ == "__main__":
-    success = test_optimization()
-    exit(0 if success else 1)
+    test_optimization()


### PR DESCRIPTION
## Summary
- replace the old grid search with an Optuna study
- integrate OptunaSearch with Ray Tune
- update docs to describe Optuna-based fallback
- adjust optimization tests for Optuna output

## Testing
- `pytest tests/test_streamlined_optimization.py::test_optimization -q`

------
https://chatgpt.com/codex/tasks/task_e_6869bbf5700c832e9b1eaca356b60cba

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that Optuna is now used for hyperparameter optimization, with optional Ray Tune integration.

* **New Features**
  * Enhanced hyperparameter optimization by consistently using Optuna, either standalone or with Ray Tune, replacing the previous grid search fallback.

* **Tests**
  * Improved test assertions to validate optimization results and simplified test execution logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->