### PR TITLE
Add VADER-based sentiment analysis

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -42,6 +42,7 @@ pynvml>=11.0.0,<12.0.0        # NVIDIA GPU monitoring
 optuna>=3.0.0,<4.0.0         # Hyperparameter optimization
 feedparser>=6.0.0,<7.0.0    # RSS feed parsing for news sentiment
 empyrical>=0.5.3
+vaderSentiment>=3.3.2
 
 # Add missing dependencies for web requests, HTML parsing, and system monitoring
 requests>=2.28.0,<3.0.0  # HTTP requests for sentiment and data fetching

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ pynvml>=11.0.0,<12.0.0        # NVIDIA GPU monitoring
 optuna>=3.0.0,<4.0.0         # Hyperparameter optimization
 feedparser>=6.0.0,<7.0.0    # RSS feed parsing for news sentiment
 empyrical>=0.5.3
+vaderSentiment>=3.3.2
 typer[all]>=0.9.0
 
 # Add missing dependencies for web requests, HTML parsing, and system monitoring

--- a/src/data/forex_sentiment.py
+++ b/src/data/forex_sentiment.py
@@ -53,7 +53,7 @@ def analyze_text_sentiment(text: str) -> float:
         scores = analyzer.polarity_scores(text)
         return float(scores.get("compound", 0.0))
     except Exception as exc:  # pragma: no cover - failure path
-        print(f"VADER sentiment failed for text '{text}': {exc}")
+        logger.warning(f"VADER sentiment failed for text '{text}': {exc}")
         return 0.0
 
 

--- a/src/data/forex_sentiment.py
+++ b/src/data/forex_sentiment.py
@@ -45,37 +45,16 @@ def scrape_yahoo_finance_forex_headlines(
 
 
 def analyze_text_sentiment(text: str) -> float:
-    positive_words = [
-        "bullish",
-        "growth",
-        "profit",
-        "gain",
-        "up",
-        "rise",
-        "strong",
-        "beat",
-        "outperform",
-    ]
-    negative_words = [
-        "bearish",
-        "loss",
-        "decline",
-        "down",
-        "fall",
-        "weak",
-        "miss",
-        "underperform",
-        "drop",
-    ]
-    text_lower = text.lower()
-    positive_count = sum(1 for word in positive_words if word in text_lower)
-    negative_count = sum(1 for word in negative_words if word in text_lower)
-    if positive_count + negative_count == 0:
+    """Analyze sentiment of a headline using VADER."""
+    try:
+        from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+
+        analyzer = SentimentIntensityAnalyzer()
+        scores = analyzer.polarity_scores(text)
+        return float(scores.get("compound", 0.0))
+    except Exception as exc:  # pragma: no cover - failure path
+        print(f"VADER sentiment failed for text '{text}': {exc}")
         return 0.0
-    sentiment_score = (positive_count - negative_count) / (
-        positive_count + negative_count
-    )
-    return max(-1.0, min(1.0, sentiment_score))
 
 
 def get_forex_sentiment(pair: str) -> list[ForexSentimentData]:

--- a/src/data/sentiment.py
+++ b/src/data/sentiment.py
@@ -66,10 +66,7 @@ class NewsSentimentProvider(SentimentProvider):
     def _analyze_text_sentiment(text: str) -> float:
         """Analyze text sentiment using the VADER compound score."""
         try:
-            from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
-
-            analyzer = SentimentIntensityAnalyzer()
-            scores = analyzer.polarity_scores(text)
+            scores = VADER_ANALYZER.polarity_scores(text)
             return float(scores.get("compound", 0.0))
         except Exception as exc:  # pragma: no cover - failure path
             logger.warning(f"VADER sentiment failed for text '{text}': {exc}")

--- a/src/data/sentiment.py
+++ b/src/data/sentiment.py
@@ -64,38 +64,16 @@ class NewsSentimentProvider(SentimentProvider):
 
     @staticmethod
     def _analyze_text_sentiment(text: str) -> float:
-        """Simple sentiment analysis using keyword matching."""
-        positive_words = [
-            "bullish",
-            "growth",
-            "profit",
-            "gain",
-            "up",
-            "rise",
-            "strong",
-            "beat",
-            "outperform",
-        ]
-        negative_words = [
-            "bearish",
-            "loss",
-            "decline",
-            "down",
-            "fall",
-            "weak",
-            "miss",
-            "underperform",
-            "drop",
-        ]
-        text_lower = text.lower()
-        positive_count = sum(1 for word in positive_words if word in text_lower)
-        negative_count = sum(1 for word in negative_words if word in text_lower)
-        if positive_count + negative_count == 0:
+        """Analyze text sentiment using the VADER compound score."""
+        try:
+            from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+
+            analyzer = SentimentIntensityAnalyzer()
+            scores = analyzer.polarity_scores(text)
+            return float(scores.get("compound", 0.0))
+        except Exception as exc:  # pragma: no cover - failure path
+            logger.warning(f"VADER sentiment failed for text '{text}': {exc}")
             return 0.0
-        sentiment_score = (positive_count - negative_count) / (
-            positive_count + negative_count
-        )
-        return max(-1.0, min(1.0, sentiment_score))
 
     @staticmethod
     def _get_mock_news_sentiment_static(

--- a/tests/test_forex_sentiment.py
+++ b/tests/test_forex_sentiment.py
@@ -47,7 +47,7 @@ def test_analyze_text_sentiment():
     neu = analyze_text_sentiment("EURUSD trading sideways")
     assert pos > 0
     assert neg < 0
-    assert neu == 0.0
+    assert abs(neu) < 0.1
 
 
 @patch("src.data.forex_sentiment.requests.get")

--- a/tests/test_forex_sentiment.py
+++ b/tests/test_forex_sentiment.py
@@ -47,7 +47,7 @@ def test_analyze_text_sentiment():
     neu = analyze_text_sentiment("EURUSD trading sideways")
     assert pos > 0
     assert neg < 0
-    assert abs(neu) < 0.1
+    assert abs(neu) < NEUTRAL_SENTIMENT_THRESHOLD
 
 
 @patch("src.data.forex_sentiment.requests.get")

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -93,7 +93,7 @@ class TestSentimentProviders:
 
         assert pos_score > 0
         assert neg_score < 0
-        assert neu_score == 0.0
+        assert abs(neu_score) < 0.1
 
     def test_social_provider_mock_sentiment(self):
         """Test social provider returns mock sentiment data."""

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -93,7 +93,7 @@ class TestSentimentProviders:
 
         assert pos_score > 0
         assert neg_score < 0
-        assert abs(neu_score) < 0.1
+        assert abs(neu_score) < NEUTRAL_THRESHOLD
 
     def test_social_provider_mock_sentiment(self):
         """Test social provider returns mock sentiment data."""


### PR DESCRIPTION
## Summary
- add `vaderSentiment` dependency
- use VADER to score sentiment in `sentiment.py` and `forex_sentiment.py`
- relax tests around neutral sentiment scores

## Testing
- `pytest tests/test_sentiment.py::TestSentimentProviders::test_news_provider_text_sentiment -q`
- `pytest -q` *(fails: ImportError: talib._ta_lib)*

------
https://chatgpt.com/codex/tasks/task_e_686a895b2a8c832eb7b1e36872e86510

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated VADER sentiment analysis for more advanced sentiment scoring in text analysis.

* **Chores**
  * Added the VADER sentiment analysis library to the list of required dependencies.

* **Tests**
  * Updated sentiment analysis tests to allow for small deviations in neutral sentiment scores, improving test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->