### PR TITLE
Rewrite create_sequences with sliding_window_view

### DIFF
--- a/tests/focused/test_preprocessing_features.py
+++ b/tests/focused/test_preprocessing_features.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 
 from src.data.features import compute_bollinger_bands, compute_macd
-from src.data.preprocessing import preprocess_trading_data
+from src.data.preprocessing import preprocess_trading_data, create_sequences
 
 
 def test_normalize_invalid_method():
@@ -43,3 +43,25 @@ def test_feature_generators_basic():
     assert upper.isna().iloc[:2].all()
     macd_df = compute_macd(data.copy(), price_col="close")
     assert {"macd_line", "macd_signal", "macd_hist"}.issubset(macd_df.columns)
+
+
+def test_create_sequences_stride_dataframe():
+    df = pd.DataFrame(
+        {
+            "f1": np.arange(6, dtype=float),
+            "f2": np.arange(10, 16, dtype=float),
+            "target": np.arange(20, 26, dtype=float),
+        }
+    )
+    seq, tgt = create_sequences(df, sequence_length=2, target_column="target", stride=2)
+
+    expected_seq = np.array(
+        [
+            [[0.0, 10.0], [1.0, 11.0]],
+            [[2.0, 12.0], [3.0, 13.0]],
+        ]
+    )
+    expected_tgt = np.array([[22.0], [24.0]])
+
+    assert np.array_equal(seq, expected_seq)
+    assert np.array_equal(tgt, expected_tgt)


### PR DESCRIPTION
## Summary
- refactor `create_sequences` to use numpy's `sliding_window_view`
- keep dataframe support
- test new stride behaviour

## Testing
- `pytest -q tests/focused/test_preprocessing_features.py` *(fails: ImportError: undefined symbol TA_AVGDEV_Lookback)*

------
https://chatgpt.com/codex/tasks/task_e_686a957bedd8832e907672a64e3a993d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability and efficiency of sequence generation when handling feature data, ensuring consistent output shapes and better performance.

* **Tests**
  * Added a new test to verify correct sequence and target extraction from multi-feature data with custom stride settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->