### PR TITLE
Integrate quantstats for metrics

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -51,6 +51,10 @@ psutil>=5.9.0,<6.0
 backtrader>=1.9.78
 riskfolio-lib>=7.0.1
 
+# Performance analytics
+quantstats>=0.0.64
+ipython>=8.0
+
 # FinRL & related dependencies
 finrl>=0.3.7
 alpaca-py>=0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,10 @@ psutil>=5.9.0,<6.0
 backtrader>=1.9.78
 riskfolio-lib>=7.0.1
 
+# Performance analytics
+quantstats>=0.0.64
+ipython>=8.0
+
 # FinRL & related dependencies
 finrl>=0.3.7
 alpaca-py>=0.4.0

--- a/tests/test_quantstats_metrics.py
+++ b/tests/test_quantstats_metrics.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pandas as pd
+import quantstats.stats as qs
+
+from src.utils import metrics
+
+
+def _sample_series():
+    data = [0.1, -0.05, 0.2, -0.1]
+    idx = pd.date_range("2020-01-01", periods=len(data))
+    return pd.Series(data, index=idx)
+
+
+def test_profit_factor_matches_quantstats():
+    series = _sample_series()
+    expected = qs.profit_factor(series)
+    assert np.isclose(metrics.calculate_profit_factor(series), expected)
+
+
+def test_win_rate_matches_quantstats():
+    series = _sample_series()
+    expected = qs.win_rate(series)
+    assert np.isclose(metrics.calculate_win_rate(series), expected)
+
+
+def test_avg_win_loss_ratio_matches_quantstats():
+    series = _sample_series()
+    expected = qs.win_loss_ratio(series)
+    assert np.isclose(metrics.calculate_average_win_loss_ratio(series), expected)


### PR DESCRIPTION
## Summary
- add quantstats and ipython dependencies
- calculate profit factor, win rate and avg win/loss ratio via quantstats
- update comprehensive metrics accordingly
- test new metric functions

## Testing
- `pytest tests/test_quantstats_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686a9b7ac8b0832ea81a5fbab74de70e