### PR TITLE
Add targeted unit tests with high coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,3 +152,14 @@ def production_dataset_path():
 
 # Backward compatibility - alias for existing tests
 trading_env = finrl_trading_env
+
+@pytest.fixture
+def basic_trading_env(sample_csv_file):
+    """Return a minimal :class:`TradingEnv` using ``sample_csv_file``."""
+    from src.envs.finrl_trading_env import TradingEnv
+
+    cfg = {"dataset_paths": sample_csv_file, "reward_type": "profit"}
+    env = TradingEnv(cfg)
+    yield env
+    if hasattr(env, "close"):
+        env.close()

--- a/tests/performance/test_trainer.py
+++ b/tests/performance/test_trainer.py
@@ -392,6 +392,3 @@ class TestTrainerIntegration:
             assert trainer.ray_config["framework"] == "torch"
             assert trainer.ray_config["num_workers"] == 2
             assert trainer.ray_config["env_config"] == env_cfg
-
-
-@pytest.mark.integration

--- a/tests/unit/test_cnn_lstm_model_more.py
+++ b/tests/unit/test_cnn_lstm_model_more.py
@@ -1,0 +1,29 @@
+import torch
+import yaml
+import pytest
+
+from src.models import CNNLSTMModel
+
+pytestmark = pytest.mark.unit
+
+
+def test_attention_forward_pass():
+    cfg = {"cnn_filters": [2], "cnn_kernel_sizes": [2], "lstm_units": 4, "dropout": 0.0}
+    model = CNNLSTMModel(input_dim=3, config=cfg, use_attention=True)
+    x = torch.randn(1, 5, 3)
+    out = model(x)
+    assert out.shape == (1, 1)
+
+
+def test_invalid_config(tmp_path):
+    bad_cfg = tmp_path / "cfg.yaml"
+    bad_cfg.write_text("- 1\n- 2\n")
+    with pytest.raises(ValueError):
+        CNNLSTMModel(input_dim=2, config=str(bad_cfg))
+
+
+def test_feature_mismatch():
+    model = CNNLSTMModel(input_dim=4, config={"cnn_filters": [2], "cnn_kernel_sizes": [2], "lstm_units": 4, "dropout":0.0})
+    bad_input = torch.randn(1, 5, 3)
+    with pytest.raises(ValueError):
+        model(bad_input)

--- a/tests/unit/test_metrics_calculations_new.py
+++ b/tests/unit/test_metrics_calculations_new.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pandas as pd
+import quantstats.stats as qs
+import pytest
+
+from src.utils import metrics
+
+pytestmark = pytest.mark.unit
+
+
+def test_sharpe_ratio_with_risk_free():
+    r = np.array([0.01, 0.02, -0.005])
+    rf = 0.01
+    expected = metrics._empyrical.sharpe_ratio(r, risk_free=rf)
+    result = metrics.calculate_sharpe_ratio(r, risk_free_rate=rf)
+    assert np.isclose(result, expected)
+
+
+def test_drawdown_and_profit_factor():
+    idx = pd.date_range("2020-01-01", periods=4)
+    data = pd.Series([0.1, -0.05, 0.02, -0.02], index=idx)
+    dd = metrics.calculate_max_drawdown(data)
+    assert dd <= 0
+    pf = metrics.calculate_profit_factor(data)
+    assert np.isclose(pf, qs.profit_factor(data))
+    win_rate = metrics.calculate_win_rate(data)
+    assert np.isclose(win_rate, qs.win_rate(data))

--- a/tests/unit/test_pipeline_load_cached_csvs_new.py
+++ b/tests/unit/test_pipeline_load_cached_csvs_new.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pytest
+
+from src.data.pipeline import load_cached_csvs
+
+pytestmark = pytest.mark.unit
+
+
+def test_load_cached_csvs_multiple(sample_csv_file, tmp_path):
+    df = pd.read_csv(sample_csv_file)
+    sub = tmp_path / "data"
+    sub.mkdir()
+    path1 = sub / "a.csv"
+    path2 = sub / "b.csv"
+    df.to_csv(path1, index=False)
+    df.to_csv(path2, index=False)
+    combined = load_cached_csvs(sub)
+    assert len(combined) == len(df) * 2
+    assert set(combined["source"].unique()) == {"a", "b"}

--- a/tests/unit/test_trading_env_reset_step_new.py
+++ b/tests/unit/test_trading_env_reset_step_new.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+
+from src.envs.finrl_trading_env import TradingEnv
+
+pytestmark = pytest.mark.unit
+
+
+def _make_env(path):
+    return TradingEnv({"dataset_paths": path, "reward_type": "sharpe"})
+
+
+def test_reset_clears_history(sample_csv_file):
+    env = _make_env(sample_csv_file)
+    env.reset()
+    env.step(np.zeros(env.action_space.shape))
+    assert env._return_history  # history recorded
+    env.reset()
+    assert env._return_history == []
+
+
+def test_dataset_path_string(sample_csv_file):
+    env = TradingEnv({"dataset_paths": sample_csv_file})
+    obs, info = env.reset()
+    assert obs is not None and isinstance(info, dict)

--- a/tests/unit/test_trainer_minimal_loops.py
+++ b/tests/unit/test_trainer_minimal_loops.py
@@ -1,0 +1,45 @@
+from unittest.mock import Mock, patch
+import types
+import pytest
+
+from src.agents import trainer as trainer_module
+
+pytestmark = pytest.mark.unit
+
+
+def _make_configs(tmp_path, sample_csv_file):
+    env_cfg = {"dataset_paths": [sample_csv_file]}
+    model_cfg = {}
+    trainer_cfg = {}
+    return env_cfg, model_cfg, trainer_cfg
+
+
+def test_train_invokes_tuner(tmp_path, sample_csv_file):
+    env_cfg, model_cfg, trainer_cfg = _make_configs(tmp_path, sample_csv_file)
+    calls = {}
+    with (
+        patch.object(trainer_module.ray, "is_initialized", return_value=False),
+        patch.object(trainer_module.ray, "init", lambda **kw: calls.setdefault("init", kw)),
+        patch.object(trainer_module, "register_env", lambda: None),
+        patch.object(trainer_module.ray, "shutdown", lambda: calls.setdefault("shutdown", True)),
+        patch.object(trainer_module.tune, "Tuner") as tuner_cls,
+    ):
+        tuner = types.SimpleNamespace(fit=lambda: calls.setdefault("fit", True))
+        tuner_cls.return_value = tuner
+        t = trainer_module.Trainer(env_cfg, model_cfg, trainer_cfg, save_dir=str(tmp_path))
+        t.train()
+    assert calls.get("fit") and calls.get("shutdown")
+
+
+def test_evaluate_and_test_not_implemented(tmp_path, sample_csv_file):
+    env_cfg, model_cfg, trainer_cfg = _make_configs(tmp_path, sample_csv_file)
+    with (
+        patch.object(trainer_module.ray, "is_initialized", return_value=False),
+        patch.object(trainer_module.ray, "init"),
+        patch.object(trainer_module, "register_env"),
+    ):
+        t = trainer_module.Trainer(env_cfg, model_cfg, trainer_cfg, save_dir=str(tmp_path))
+        with pytest.raises(NotImplementedError):
+            t.evaluate()
+        with pytest.raises(NotImplementedError):
+            t.test()


### PR DESCRIPTION
## Summary
- add `basic_trading_env` fixture for simple environment setup
- add new unit tests for metrics calculations
- expand pipeline tests for multiple CSV concatenation
- test TradingEnv reset behaviour and dataset path handling
- improve CNNLSTMModel coverage with attention and error checks
- add minimal Trainer loop tests using mocks
- fix stray line in performance test to allow collection

## Testing
- `pytest tests/unit/test_metrics_basic.py tests/unit/test_metrics_additional.py tests/unit/test_quantstats_metrics.py tests/unit/test_pipeline_helpers.py tests/unit/test_trading_env_basic.py tests/unit/test_cnn_lstm.py tests/unit/test_trainer_loops.py tests/unit/test_metrics_calculations_new.py tests/unit/test_pipeline_load_cached_csvs_new.py tests/unit/test_trading_env_reset_step_new.py tests/unit/test_cnn_lstm_model_more.py tests/unit/test_trainer_minimal_loops.py`

------
https://chatgpt.com/codex/tasks/task_e_686c0bedd504832e989754ea5052a56f