### PR TITLE
Add nltk dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ _Current status: core functionality validated, environment testing framework com
 2. **Install dependencies**
 
    ```bash
+   pip install -r requirements.txt
    pip install -r requirements-finrl.txt
    pip install finrl[full] "ray[rllib]"
    ```
+
+   The base requirements file now includes `nltk>=3.8` for sentiment analysis.
 
 3. **Run tests**
    ```bash

--- a/TESTING.md
+++ b/TESTING.md
@@ -11,6 +11,9 @@ pip install -r requirements.txt
 pip install -r requirements-test.txt
 ```
 
+`nltk>=3.8` is included in the base requirements and is required for the
+sentiment analysis tests.
+
 For machine-learning features (PyTorch and RLlib) install additional packages:
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,8 @@ optuna>=3.0.0,<4.0.0         # Hyperparameter optimization
 feedparser>=6.0.0,<7.0.0    # RSS feed parsing for news sentiment
 empyrical>=0.5.3
 vaderSentiment>=3.3.2
-nltk>=3.8
+-nltk>=3.8
++nltk>=3.8,<4.0.0
 typer[all]>=0.9.0
 
 # Add missing dependencies for web requests, HTML parsing, and system monitoring

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ optuna>=3.0.0,<4.0.0         # Hyperparameter optimization
 feedparser>=6.0.0,<7.0.0    # RSS feed parsing for news sentiment
 empyrical>=0.5.3
 vaderSentiment>=3.3.2
+nltk>=3.8
 typer[all]>=0.9.0
 
 # Add missing dependencies for web requests, HTML parsing, and system monitoring


### PR DESCRIPTION
## Summary
- include `nltk>=3.8` in `requirements.txt`
- update install instructions in README
- note new dependency in TESTING guide

## Testing
- `pytest tests/unit/test_nlp_sentiment.py -q` *(fails: IndexError in AverageTrueRange)*

------
https://chatgpt.com/codex/tasks/task_e_686c6f0582fc832e9dd449c3dfb8c001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified installation steps in the README and testing documentation, highlighting the inclusion of `nltk>=3.8` for sentiment analysis.
* **Chores**
  * Updated `nltk` dependency to specify version `>=3.8,<4.0.0` for better version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->