### PR TITLE
Update old src imports to new package path

### DIFF
--- a/.github/workflows/comprehensive-testing.yml
+++ b/.github/workflows/comprehensive-testing.yml
@@ -195,10 +195,10 @@ jobs:
 
     - name: Import tests
       run: |
-        python -c "import src.agents; print('✅ Agents module imported')"
-        python -c "import src.data; print('✅ Data module imported')"
-        python -c "import src.envs; print('✅ Envs module imported')"
-        python -c "import src.utils; print('✅ Utils module imported')"
+        python -c "import trading_rl_agent.agents; print('✅ Agents module imported')"
+        python -c "import trading_rl_agent.data; print('✅ Data module imported')"
+        python -c "import trading_rl_agent.envs; print('✅ Envs module imported')"
+        python -c "import trading_rl_agent.utils; print('✅ Utils module imported')"
 
   # =============================================================================
   # UNIT TESTS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,8 +302,8 @@ import pandas as pd
 from unittest.mock import Mock, patch
 from pathlib import Path
 
-from src.agents.td3_agent import TD3Agent
-from src.agents.configs import TD3Config
+from trading_rl_agent.agents.td3_agent import TD3Agent
+from trading_rl_agent.agents.configs import TD3Config
 
 
 class TestTD3Agent:

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -33,8 +33,8 @@ src/trading_rl_agent/monitoring/    # Performance monitoring
 
 ```python
 # OLD IMPORTS (still work via compatibility layer)
-from src.agents import SACAgent
-from src.envs import TradingEnv
+from trading_rl_agent.agents import SACAgent
+from trading_rl_agent.envs import TradingEnv
 
 # NEW IMPORTS (recommended)
 from trading_rl_agent.agents import SACAgent
@@ -52,9 +52,9 @@ from trading_rl_agent.risk import RiskManager            # NEW
 **Old Code:**
 
 ```python
-from src.agents.sac_agent import SACAgent
-from src.envs.trading_env import TradingEnv
-from src.models.cnn_lstm import CNNLSTMModel
+from trading_rl_agent.agents.sac_agent import SACAgent
+from trading_rl_agent.envs.trading_env import TradingEnv
+from trading_rl_agent.models.cnn_lstm import CNNLSTMModel
 ```
 
 **New Code:**
@@ -201,8 +201,8 @@ print(f"Max Drawdown: {current_metrics['max_drawdown']}")
 **Old Test Code:**
 
 ```python
-from src.agents.sac_agent import SACAgent
-from src.envs.trading_env import TradingEnv
+from trading_rl_agent.agents.sac_agent import SACAgent
+from trading_rl_agent.envs.trading_env import TradingEnv
 
 def test_agent_training():
     agent = SACAgent(state_dim=10, action_dim=3)
@@ -346,7 +346,7 @@ ImportError: No module named 'src.agents'
 try:
     from trading_rl_agent.agents import SACAgent
 except ImportError:
-    from src.agents.sac_agent import SACAgent  # Fallback
+    from trading_rl_agent.agents.sac_agent import SACAgent  # Fallback
 ```
 
 ### **Issue 2: Configuration Loading**

--- a/cli.py
+++ b/cli.py
@@ -9,9 +9,9 @@ import typer
 
 from evaluate_agent import main as eval_main
 from finrl_data_loader import load_real_data, load_synthetic_data
-from src.backtesting import Backtester
-from src.training.cnn_lstm import CNNLSTMTrainer
-from src.training.rl import main as rl_main
+from trading_rl_agent.backtesting import Backtester
+from trading_rl_agent.training.cnn_lstm import CNNLSTMTrainer
+from trading_rl_agent.training.rl import main as rl_main
 
 # Module-level default options to avoid function calls in defaults
 GEN_DATA_CONFIG = typer.Option(..., help="Path to data config YAML")
@@ -124,7 +124,7 @@ def serve(
     try:
         from ray import serve as ray_serve
 
-        from src.serve_deployment import deployment_graph
+        from trading_rl_agent.serve_deployment import deployment_graph
     except ImportError:
         typer.secho(
             "Ray Serve is not installed or src.serve_deployment missing.",

--- a/debug_env.py
+++ b/debug_env.py
@@ -10,7 +10,7 @@ import tempfile
 import numpy as np
 import pandas as pd
 
-from src.envs.trading_env import TradingEnv
+from trading_rl_agent.envs.trading_env import TradingEnv
 
 
 def debug_environment():

--- a/docs/ADVANCED_DATASET_DOCUMENTATION.md
+++ b/docs/ADVANCED_DATASET_DOCUMENTATION.md
@@ -192,7 +192,7 @@ data/
 ### Training the Model
 
 ```python
-from src.envs.trader_env import TraderEnv
+from trading_rl_agent.envs.trader_env import TraderEnv
 
 # Create training environment
 env = TraderEnv(['data/sample_data.csv'], window_size=10, initial_balance=10000)
@@ -205,8 +205,8 @@ env = TraderEnv(['data/sample_data.csv'], window_size=10, initial_balance=10000)
 ### Live Data Integration
 
 ```python
-from src.data.features import generate_features
-from src.data.live import fetch_live_data
+from trading_rl_agent.data.features import generate_features
+from trading_rl_agent.data.live import fetch_live_data
 
 # Fetch live data
 live_data = fetch_live_data("AAPL", start="2025-06-15", end="2025-06-16")
@@ -325,7 +325,7 @@ hyperparameter search. When Ray Tune is available it integrates with
 Example usage:
 
 ```python
-from src.optimization.cnn_lstm_optimization import optimize_cnn_lstm
+from trading_rl_agent.optimization.cnn_lstm_optimization import optimize_cnn_lstm
 from ray import tune
 
 results = optimize_cnn_lstm(

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -113,11 +113,11 @@ jupyter nbconvert --clear-output --inplace *.ipynb
 
 ```python
 # CNN-LSTM optimization
-from src.optimization.cnn_lstm_optimization import optimize_cnn_lstm
+from trading_rl_agent.optimization.cnn_lstm_optimization import optimize_cnn_lstm
 results = optimize_cnn_lstm(features, targets, num_samples=20)
 
 # RL optimization
-from src.optimization.rl_optimization import optimize_sac_hyperparams
+from trading_rl_agent.optimization.rl_optimization import optimize_sac_hyperparams
 results = optimize_sac_hyperparams(env_config, num_samples=10)
 ```
 

--- a/docs/EVALUATION_GUIDE.md
+++ b/docs/EVALUATION_GUIDE.md
@@ -148,7 +148,7 @@ python scripts/compare_agents.py \
 ### Rolling Performance Analysis
 
 ```python
-from src.evaluation.rolling_metrics import RollingMetricsCalculator
+from trading_rl_agent.evaluation.rolling_metrics import RollingMetricsCalculator
 
 # Analyze performance over time
 calculator = RollingMetricsCalculator(window=252)  # 1 year rolling
@@ -161,7 +161,7 @@ rolling_metrics = calculator.calculate(
 ### Risk Attribution Analysis
 
 ```python
-from src.evaluation.risk_attribution import RiskAttributor
+from trading_rl_agent.evaluation.risk_attribution import RiskAttributor
 
 # Decompose risk sources
 attributor = RiskAttributor()
@@ -176,7 +176,7 @@ risk_breakdown = attributor.analyze(
 ### Performance Plots
 
 ```python
-from src.utils.plotting import create_performance_dashboard
+from trading_rl_agent.utils.plotting import create_performance_dashboard
 
 # Generate comprehensive performance dashboard
 dashboard = create_performance_dashboard(
@@ -256,7 +256,7 @@ Before deploying to live trading:
 
 ```python
 # Debug evaluation step-by-step
-from src.evaluation.debug_evaluator import DebugEvaluator
+from trading_rl_agent.evaluation.debug_evaluator import DebugEvaluator
 
 debugger = DebugEvaluator()
 debug_results = debugger.evaluate_with_diagnostics(

--- a/docs/RAY_RLLIB_MIGRATION.md
+++ b/docs/RAY_RLLIB_MIGRATION.md
@@ -61,7 +61,7 @@ config.training(
 ### 3. Hyperparameter Optimization
 
 ```python
-from src.optimization.rl_optimization import optimize_sac_hyperparams
+from trading_rl_agent.optimization.rl_optimization import optimize_sac_hyperparams
 
 results = optimize_sac_hyperparams(env_config, num_samples=20)
 ```
@@ -78,8 +78,8 @@ While TD3 is no longer available in Ray RLlib, this project maintains a **custom
 ### Usage of Custom TD3
 
 ```python
-from src.agents.td3_agent import TD3Agent
-from src.agents.configs import TD3Config
+from trading_rl_agent.agents.td3_agent import TD3Agent
+from trading_rl_agent.agents.configs import TD3Config
 
 # Create custom TD3 agent
 config = TD3Config(

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -5,9 +5,9 @@ This section provides practical examples of using the Trading RL Agent.
 ## Basic Training Example
 
 ```python
-from src.agents.sac_agent import SACAgent
-from src.envs.trading_env import TradingEnv
-from src.agents.configs import SACConfig
+from trading_rl_agent.agents.sac_agent import SACAgent
+from trading_rl_agent.envs.trading_env import TradingEnv
+from trading_rl_agent.agents.configs import SACConfig
 
 # Create environment
 env_config = {
@@ -58,8 +58,8 @@ for episode in range(1000):
 ## Data Processing Example
 
 ```python
-from src.data.features import generate_features
-from src.data.live import fetch_live_data
+from trading_rl_agent.data.features import generate_features
+from trading_rl_agent.data.live import fetch_live_data
 import pandas as pd
 
 # Load historical data
@@ -83,7 +83,7 @@ print(features_df.head())
 ## Hyperparameter Optimization Example
 
 ```python
-from src.optimization.ray_tune_optimizer import RayTuneOptimizer
+from trading_rl_agent.optimization.ray_tune_optimizer import RayTuneOptimizer
 from ray import tune
 
 # Define hyperparameter search space
@@ -116,9 +116,9 @@ print(f"Best config: {results.best_config}")
 ## Live Trading Example
 
 ```python
-from src.agents.sac_agent import SACAgent
-from src.data.live import LiveDataProvider
-from src.trading.portfolio import Portfolio
+from trading_rl_agent.agents.sac_agent import SACAgent
+from trading_rl_agent.data.live import LiveDataProvider
+from trading_rl_agent.trading.portfolio import Portfolio
 import time
 
 # Load trained agent
@@ -158,7 +158,7 @@ while True:
 ## Custom Environment Example
 
 ```python
-from src.envs.trading_env import TradingEnv
+from trading_rl_agent.envs.trading_env import TradingEnv
 import gymnasium as gym
 from gymnasium import spaces
 import numpy as np
@@ -229,8 +229,8 @@ env = CustomTradingEnv(config)
 ## Model Evaluation Example
 
 ```python
-from src.evaluation.evaluator import ModelEvaluator
-from src.utils.metrics import calculate_trading_metrics
+from trading_rl_agent.evaluation.evaluator import ModelEvaluator
+from trading_rl_agent.utils.metrics import calculate_trading_metrics
 import matplotlib.pyplot as plt
 
 # Load trained model
@@ -271,8 +271,8 @@ plt.show()
 ## Backtesting Example
 
 ```python
-from src.backtesting.backtester import Backtester
-from src.data.historical import HistoricalDataProvider
+from trading_rl_agent.backtesting.backtester import Backtester
+from trading_rl_agent.data.historical import HistoricalDataProvider
 from datetime import datetime
 
 # Load historical data
@@ -316,9 +316,9 @@ backtester.generate_report(results, 'backtest_report.html')
 ## Advanced Configuration Example
 
 ```python
-from src.agents.configs import SACConfig
-from src.optimization.config import OptimizationConfig
-from src.data.config import DataConfig
+from trading_rl_agent.agents.configs import SACConfig
+from trading_rl_agent.optimization.config import OptimizationConfig
+from trading_rl_agent.data.config import DataConfig
 
 # Advanced SAC configuration
 sac_config = SACConfig(

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -50,9 +50,9 @@ python ../finrl_data_loader.py --config ../configs/finrl_real_data.yaml
 ### 2. Initialize the Hybrid System
 
 ```python
-from src.envs.trading_env import TradingEnv
-from src.agents.sac_agent import SACAgent
-from src.models.cnn_lstm_model import CNNLSTMModel
+from trading_rl_agent.envs.trading_env import TradingEnv
+from trading_rl_agent.agents.sac_agent import SACAgent
+from trading_rl_agent.models.cnn_lstm_model import CNNLSTMModel
 
 # Load data generated via FinRL
 env = TradingEnv(

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,8 +38,8 @@ api_reference
 ## Quick Start
 
 ```python
-from src.envs.trading_env import TradingEnv
-from src.agents.sac_agent import SACAgent
+from trading_rl_agent.envs.trading_env import TradingEnv
+from trading_rl_agent.agents.sac_agent import SACAgent
 
 # Initialize hybrid environment with production dataset
 env = TradingEnv(

--- a/evaluate_agent.py
+++ b/evaluate_agent.py
@@ -21,11 +21,11 @@ from pathlib import Path
 
 import numpy as np
 
-from src.agents.policy_utils import CallablePolicy, WeightedEnsembleAgent
-from src.agents.sac_agent import SACAgent
-from src.agents.td3_agent import TD3Agent
-from src.envs.trading_env import TradingEnv
-from src.utils import metrics
+from trading_rl_agent.agents.policy_utils import CallablePolicy, WeightedEnsembleAgent
+from trading_rl_agent.agents.sac_agent import SACAgent
+from trading_rl_agent.agents.td3_agent import TD3Agent
+from trading_rl_agent.envs.trading_env import TradingEnv
+from trading_rl_agent.utils import metrics
 
 
 def parse_args() -> argparse.Namespace:

--- a/finrl_data_loader.py
+++ b/finrl_data_loader.py
@@ -8,7 +8,7 @@ import yaml
 
 from finrl.meta.data_processor import DataProcessor
 from finrl.meta.preprocessor.preprocessors import FeatureEngineer
-from src.data.synthetic import generate_gbm_prices
+from trading_rl_agent.data.synthetic import generate_gbm_prices
 
 
 def load_real_data(config_path: str) -> pd.DataFrame:

--- a/scripts/comprehensive_cleanup.py
+++ b/scripts/comprehensive_cleanup.py
@@ -168,15 +168,15 @@ class TradingRLCleaner:
 ## Usage
 ```python
 # CNN-LSTM optimization
-from src.optimization.cnn_lstm_optimization import optimize_cnn_lstm
+from trading_rl_agent.optimization.cnn_lstm_optimization import optimize_cnn_lstm
 results = optimize_cnn_lstm(features, targets, num_samples=20)
 
 # RL optimization
-from src.optimization.rl_optimization import optimize_sac_hyperparams
+from trading_rl_agent.optimization.rl_optimization import optimize_sac_hyperparams
 results = optimize_sac_hyperparams(env_config, num_samples=10)
 
 # Model analysis
-from src.optimization.model_utils import get_model_summary
+from trading_rl_agent.optimization.model_utils import get_model_summary
 print(get_model_summary(model, input_size=(1, 10)))
 ```
 

--- a/src/data_pipeline.py
+++ b/src/data_pipeline.py
@@ -5,7 +5,7 @@ sources, compute common technical indicators, and split the resulting dataset
 into train/validation/test segments.  It is designed to be configuration driven
 and easily extended.  Example usage:
 
->>> from src.data_pipeline import PipelineConfig, load_data, generate_features, split_by_date
+>>> from trading_rl_agent.data_pipeline import PipelineConfig, load_data, generate_features, split_by_date
 >>> cfg = PipelineConfig(sma_windows=[3], momentum_windows=[3], rsi_window=14, vol_window=5)
 >>> df = load_data({"type": "csv", "path": "prices.csv"})
 >>> features = generate_features(df, cfg)

--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,7 @@ import platform
 import psutil
 import yaml
 
-from src.agents.trainer import Trainer
+from trading_rl_agent.agents.trainer import Trainer
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/src/nlp/__init__.py
+++ b/src/nlp/__init__.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import datetime
 from typing import Dict
 
-from src.data.sentiment import (
+from trading_rl_agent.data.sentiment import (
     NewsSentimentProvider,
     SentimentData,
     SocialSentimentProvider,

--- a/src/optimization/__init__.py
+++ b/src/optimization/__init__.py
@@ -6,7 +6,7 @@ This module provides clean, working implementations of:
 3. Model inspection and profiling utilities
 
 Example usage:
->>> from src.optimization import optimize_cnn_lstm, get_model_summary
+>>> from trading_rl_agent.optimization import optimize_cnn_lstm, get_model_summary
 >>> results = optimize_cnn_lstm(features, targets, num_samples=20)
 >>> summary = get_model_summary(model, input_size=(1, 10))
 >>> print(summary)

--- a/src/optimization/cnn_lstm_optimization.py
+++ b/src/optimization/cnn_lstm_optimization.py
@@ -35,7 +35,7 @@ from ray.tune.schedulers import ASHAScheduler
 # Always assume Ray is available
 RAY_AVAILABLE = True
 
-from src.models.cnn_lstm import CNNLSTMModel
+from trading_rl_agent.models.cnn_lstm import CNNLSTMModel
 
 
 def get_default_search_space() -> dict[str, Any]:

--- a/src/optimization/rl_optimization.py
+++ b/src/optimization/rl_optimization.py
@@ -8,7 +8,7 @@ Note: TD3 has been removed from Ray RLlib 2.38.0+. Use SAC for continuous contro
 
 Example usage:
 
->>> from src.optimization.rl_optimization import optimize_sac_hyperparams
+>>> from trading_rl_agent.optimization.rl_optimization import optimize_sac_hyperparams
 >>> results = optimize_sac_hyperparams(
 ...     env_config=env_config,
 ...     num_samples=20,
@@ -34,9 +34,9 @@ from ray.tune.registry import register_env
 from ray.tune.schedulers import ASHAScheduler
 from ray.tune.search.optuna import OptunaSearch
 
-from src.envs.finrl_trading_env import TradingEnv
-from src.models.concat_model import ConcatModel
-from src.utils.cluster import get_available_devices, init_ray
+from trading_rl_agent.envs.finrl_trading_env import TradingEnv
+from trading_rl_agent.models.concat_model import ConcatModel
+from trading_rl_agent.utils.cluster import get_available_devices, init_ray
 
 torch, _ = try_import_torch()
 logger = logging.getLogger(__name__)

--- a/src/serve_deployment.py
+++ b/src/serve_deployment.py
@@ -18,7 +18,7 @@ try:
 except Exception:  # pragma: no cover - ray might not be installed
     serve = None  # type: ignore
 
-from src.supervised_model import load_model, predict_features
+from trading_rl_agent.supervised_model import load_model, predict_features
 
 if serve:
 

--- a/src/supervised_model.py
+++ b/src/supervised_model.py
@@ -5,7 +5,7 @@ predict market trends from sequences of engineered features.  A simple training
 routine ``train_supervised`` is provided which can train the model on numpy or
 pandas inputs and optionally runs on GPU.  Example usage:
 
->>> from src.supervised_model import ModelConfig, TrainingConfig, train_supervised
+>>> from trading_rl_agent.supervised_model import ModelConfig, TrainingConfig, train_supervised
 >>> features, targets = load_some_data()
 >>> model_cfg = ModelConfig(task='classification')
 >>> train_cfg = TrainingConfig(epochs=5)

--- a/src/trading_rl_agent/agents/trainer.py
+++ b/src/trading_rl_agent/agents/trainer.py
@@ -5,7 +5,7 @@ import os
 import ray
 from ray import tune
 
-from src.envs.finrl_trading_env import register_env
+from trading_rl_agent.envs.finrl_trading_env import register_env
 
 try:
     from ray.rllib.algorithms.ppo import PPOTrainer

--- a/src/trading_rl_agent/agents/tune.py
+++ b/src/trading_rl_agent/agents/tune.py
@@ -4,7 +4,7 @@ import ray
 from ray import tune
 import yaml
 
-from src.envs.finrl_trading_env import register_env
+from trading_rl_agent.envs.finrl_trading_env import register_env
 
 
 def _convert_value(value):

--- a/src/trading_rl_agent/data/features.py
+++ b/src/trading_rl_agent/data/features.py
@@ -260,7 +260,7 @@ def compute_candle_features(df: pd.DataFrame, advanced: bool = True) -> pd.DataF
     """
     if advanced:
         # Use advanced patterns from candle_patterns.py
-        from src.data.candle_patterns import compute_all_candle_patterns
+        from trading_rl_agent.data.candle_patterns import compute_all_candle_patterns
 
         return compute_all_candle_patterns(df)
     else:

--- a/src/trading_rl_agent/data/professional_feeds.py
+++ b/src/trading_rl_agent/data/professional_feeds.py
@@ -33,7 +33,7 @@ except ImportError:
 
 import yfinance as yf
 
-from src.data.features import generate_features
+from trading_rl_agent.data.features import generate_features
 
 logger = logging.getLogger(__name__)
 

--- a/src/training/cli.py
+++ b/src/training/cli.py
@@ -1,6 +1,6 @@
 import argparse
 
-from src.agents.tune import run_tune
+from trading_rl_agent.agents.tune import run_tune
 
 from . import cnn_lstm, rl
 

--- a/src/training/cnn_lstm.py
+++ b/src/training/cnn_lstm.py
@@ -5,7 +5,7 @@ sentiment analysis and technical indicators. It supports both classification
 and regression tasks for market prediction.
 
 Example usage:
->>> from src.training.cnn_lstm import CNNLSTMTrainer, TrainingConfig
+>>> from trading_rl_agent.training.cnn_lstm import CNNLSTMTrainer, TrainingConfig
 >>> trainer = CNNLSTMTrainer()
 >>> model = trainer.train_from_config('src/configs/training/cnn_lstm_train.yaml')
 """
@@ -27,9 +27,9 @@ import pytorch_lightning as pl
 from pytorch_forecasting import TimeSeriesDataSet
 import yaml
 
-from src.data.features import generate_features
-from src.data.sentiment import SentimentAnalyzer, SentimentConfig
-from src.models.cnn_lstm import CNNLSTMModel
+from trading_rl_agent.data.features import generate_features
+from trading_rl_agent.data.sentiment import SentimentAnalyzer, SentimentConfig
+from trading_rl_agent.models.cnn_lstm import CNNLSTMModel
 
 
 # Define a simple load_data function if not available

--- a/src/training/rl.py
+++ b/src/training/rl.py
@@ -8,9 +8,9 @@ from pathlib import Path
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.rllib.models import ModelCatalog
 
-from src.envs.finrl_trading_env import TradingEnv, register_env
-from src.models.concat_model import ConcatModel
-from src.utils.cluster import get_available_devices, init_ray
+from trading_rl_agent.envs.finrl_trading_env import TradingEnv, register_env
+from trading_rl_agent.models.concat_model import ConcatModel
+from trading_rl_agent.utils.cluster import get_available_devices, init_ray
 
 
 def create_env(cfg):

--- a/test-results.xml
+++ b/test-results.xml
@@ -1,52 +1,76 @@
-<?xml version="1.0" encoding="utf-8"?><testsuites name="pytest tests"><testsuite name="pytest" errors="5" failures="0" skipped="0" tests="5" time="3.258" timestamp="2025-07-08T03:29:46.803170+00:00" hostname="0cb157972b5d"><testcase classname="" name="tests.integration.cli" time="0.000"><error message="collection failure">/usr/lib/python3.11/importlib/__init__.py:126: in import_module
-    return _bootstrap._gcd_import(name[level:], package, level)
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-&lt;frozen importlib._bootstrap&gt;:1206: in _gcd_import
-    ???
-&lt;frozen importlib._bootstrap&gt;:1178: in _find_and_load
-    ???
-&lt;frozen importlib._bootstrap&gt;:1149: in _find_and_load_unlocked
-    ???
-&lt;frozen importlib._bootstrap&gt;:690: in _load_unlocked
-    ???
-/usr/local/lib/python3.11/dist-packages/_pytest/assertion/rewrite.py:186: in exec_module
-    exec(co, module.__dict__)
-tests/integration/cli/conftest.py:8: in &lt;module&gt;
-    import src.agents as _agents
-E   ModuleNotFoundError: No module named 'src.agents'</error></testcase><testcase classname="" name="tests.integration.test_backtester_wrapper" time="0.000"><error message="collection failure">ImportError while importing test module '/workspaces/trading-rl-agent/tests/integration/test_backtester_wrapper.py'.
+<?xml version="1.0" encoding="utf-8"?><testsuites name="pytest tests"><testsuite name="pytest" errors="5" failures="0" skipped="0" tests="5" time="2.276" timestamp="2025-07-08T04:20:18.843932+00:00" hostname="df0504caa608"><testcase classname="" name="tests.unit.test_cached_data" time="0.000"><error message="collection failure">ImportError while importing test module '/workspace/trading-rl-agent/tests/unit/test_cached_data.py'.
 Hint: make sure your test modules/packages have valid Python names.
 Traceback:
-/usr/lib/python3.11/importlib/__init__.py:126: in import_module
+/root/.pyenv/versions/3.10.17/lib/python3.10/importlib/__init__.py:126: in import_module
     return _bootstrap._gcd_import(name[level:], package, level)
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-tests/integration/test_backtester_wrapper.py:4: in &lt;module&gt;
-    from src.backtesting import Backtester
-src/backtesting/__init__.py:3: in &lt;module&gt;
-    from .backtester import Backtester
-src/backtesting/backtester.py:6: in &lt;module&gt;
-    import backtrader as bt
-E   ModuleNotFoundError: No module named 'backtrader'</error></testcase><testcase classname="" name="tests.integration.test_comprehensive_data_preprocessing" time="0.000"><error message="collection failure">ImportError while importing test module '/workspaces/trading-rl-agent/tests/integration/test_comprehensive_data_preprocessing.py'.
+tests/unit/test_cached_data.py:6: in &lt;module&gt;
+    from trading_rl_agent.data.pipeline import load_cached_csvs
+src/trading_rl_agent/__init__.py:25: in &lt;module&gt;
+    from .core.config import ConfigManager, SystemConfig
+src/trading_rl_agent/core/__init__.py:8: in &lt;module&gt;
+    from .config import ConfigManager, SystemConfig
+src/trading_rl_agent/core/config.py:27: in &lt;module&gt;
+    from .logging import get_logger
+src/trading_rl_agent/core/logging.py:11: in &lt;module&gt;
+    import structlog
+E   ModuleNotFoundError: No module named 'structlog'</error></testcase><testcase classname="" name="tests.unit.test_candle_patterns" time="0.000"><error message="collection failure">ImportError while importing test module '/workspace/trading-rl-agent/tests/unit/test_candle_patterns.py'.
 Hint: make sure your test modules/packages have valid Python names.
 Traceback:
-/usr/lib/python3.11/importlib/__init__.py:126: in import_module
+/root/.pyenv/versions/3.10.17/lib/python3.10/importlib/__init__.py:126: in import_module
     return _bootstrap._gcd_import(name[level:], package, level)
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-tests/integration/test_comprehensive_data_preprocessing.py:16: in &lt;module&gt;
-    from src.data.features import (
-E   ModuleNotFoundError: No module named 'src.data'</error></testcase><testcase classname="" name="tests.integration.test_comprehensive_environments" time="0.000"><error message="collection failure">ImportError while importing test module '/workspaces/trading-rl-agent/tests/integration/test_comprehensive_environments.py'.
+tests/unit/test_candle_patterns.py:9: in &lt;module&gt;
+    from trading_rl_agent.data.candle_patterns import (
+src/trading_rl_agent/__init__.py:25: in &lt;module&gt;
+    from .core.config import ConfigManager, SystemConfig
+src/trading_rl_agent/core/__init__.py:8: in &lt;module&gt;
+    from .config import ConfigManager, SystemConfig
+src/trading_rl_agent/core/config.py:27: in &lt;module&gt;
+    from .logging import get_logger
+src/trading_rl_agent/core/logging.py:11: in &lt;module&gt;
+    import structlog
+E   ModuleNotFoundError: No module named 'structlog'</error></testcase><testcase classname="" name="tests.unit.test_cli_args" time="0.000"><error message="collection failure">ImportError while importing test module '/workspace/trading-rl-agent/tests/unit/test_cli_args.py'.
 Hint: make sure your test modules/packages have valid Python names.
 Traceback:
-/usr/lib/python3.11/importlib/__init__.py:126: in import_module
+/root/.pyenv/versions/3.10.17/lib/python3.10/importlib/__init__.py:126: in import_module
     return _bootstrap._gcd_import(name[level:], package, level)
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-tests/integration/test_comprehensive_environments.py:15: in &lt;module&gt;
-    from src.envs.finrl_trading_env import TradingEnv
-E   ModuleNotFoundError: No module named 'src.envs'</error></testcase><testcase classname="" name="tests.integration.test_data_pipeline" time="0.000"><error message="collection failure">ImportError while importing test module '/workspaces/trading-rl-agent/tests/integration/test_data_pipeline.py'.
+tests/unit/test_cli_args.py:3: in &lt;module&gt;
+    from trading_rl_agent.main import build_parser
+src/trading_rl_agent/__init__.py:25: in &lt;module&gt;
+    from .core.config import ConfigManager, SystemConfig
+src/trading_rl_agent/core/__init__.py:8: in &lt;module&gt;
+    from .config import ConfigManager, SystemConfig
+src/trading_rl_agent/core/config.py:27: in &lt;module&gt;
+    from .logging import get_logger
+src/trading_rl_agent/core/logging.py:11: in &lt;module&gt;
+    import structlog
+E   ModuleNotFoundError: No module named 'structlog'</error></testcase><testcase classname="" name="tests.unit.test_cluster_utils" time="0.000"><error message="collection failure">ImportError while importing test module '/workspace/trading-rl-agent/tests/unit/test_cluster_utils.py'.
 Hint: make sure your test modules/packages have valid Python names.
 Traceback:
-/usr/lib/python3.11/importlib/__init__.py:126: in import_module
+/root/.pyenv/versions/3.10.17/lib/python3.10/importlib/__init__.py:126: in import_module
     return _bootstrap._gcd_import(name[level:], package, level)
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-tests/integration/test_data_pipeline.py:6: in &lt;module&gt;
-    from src.data.pipeline import run_pipeline
-E   ModuleNotFoundError: No module named 'src.data'</error></testcase></testsuite></testsuites>
+tests/unit/test_cluster_utils.py:5: in &lt;module&gt;
+    from trading_rl_agent.utils.cluster import get_available_devices, init_ray
+src/trading_rl_agent/__init__.py:25: in &lt;module&gt;
+    from .core.config import ConfigManager, SystemConfig
+src/trading_rl_agent/core/__init__.py:8: in &lt;module&gt;
+    from .config import ConfigManager, SystemConfig
+src/trading_rl_agent/core/config.py:27: in &lt;module&gt;
+    from .logging import get_logger
+src/trading_rl_agent/core/logging.py:11: in &lt;module&gt;
+    import structlog
+E   ModuleNotFoundError: No module named 'structlog'</error></testcase><testcase classname="" name="tests.unit.test_cnn_lstm" time="0.000"><error message="collection failure">ImportError while importing test module '/workspace/trading-rl-agent/tests/unit/test_cnn_lstm.py'.
+Hint: make sure your test modules/packages have valid Python names.
+Traceback:
+/root/.pyenv/versions/3.10.17/lib/python3.10/importlib/__init__.py:126: in import_module
+    return _bootstrap._gcd_import(name[level:], package, level)
+tests/unit/test_cnn_lstm.py:3: in &lt;module&gt;
+    from trading_rl_agent.models import CNNLSTMModel
+src/trading_rl_agent/__init__.py:25: in &lt;module&gt;
+    from .core.config import ConfigManager, SystemConfig
+src/trading_rl_agent/core/__init__.py:8: in &lt;module&gt;
+    from .config import ConfigManager, SystemConfig
+src/trading_rl_agent/core/config.py:27: in &lt;module&gt;
+    from .logging import get_logger
+src/trading_rl_agent/core/logging.py:11: in &lt;module&gt;
+    import structlog
+E   ModuleNotFoundError: No module named 'structlog'</error></testcase></testsuite></testsuites>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,7 @@ def finrl_sample_data():
 def finrl_trading_env(finrl_sample_data):
     """Provide a FinRL-based trading environment for testing."""
     try:
-        from src.envs.finrl_trading_env import HybridFinRLEnv
+        from trading_rl_agent.envs.finrl_trading_env import HybridFinRLEnv
 
         # Create environment with minimal configuration for fast testing
         env = HybridFinRLEnv(
@@ -89,7 +89,7 @@ def finrl_trading_env(finrl_sample_data):
 
     except ImportError:
         # Fallback to simple TradingEnv using synthetic data
-        from src.envs.finrl_trading_env import TradingEnv
+        from trading_rl_agent.envs.finrl_trading_env import TradingEnv
         from tests.unit.test_data_utils import get_dynamic_test_config
 
         cfg = get_dynamic_test_config(
@@ -156,7 +156,7 @@ trading_env = finrl_trading_env
 @pytest.fixture
 def basic_trading_env(sample_csv_file):
     """Return a minimal :class:`TradingEnv` using ``sample_csv_file``."""
-    from src.envs.finrl_trading_env import TradingEnv
+    from trading_rl_agent.envs.finrl_trading_env import TradingEnv
 
     cfg = {"dataset_paths": sample_csv_file, "reward_type": "profit"}
     env = TradingEnv(cfg)

--- a/tests/conftest_extra.py
+++ b/tests/conftest_extra.py
@@ -539,7 +539,7 @@ def integration_environment(sample_csv_path, trading_env_config):
     mocks = {}
 
     try:
-        from src.envs.finrl_trading_env import TradingEnv
+        from trading_rl_agent.envs.finrl_trading_env import TradingEnv
 
         trading_env_config["dataset_paths"] = [sample_csv_path]
         env = TradingEnv(**trading_env_config)

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import yaml
 import sys
 
-import src.agents as _agents
+import trading_rl_agent.agents as _agents
 
 # Ensure the package can be imported as ``agents`` when calling the CLI.
 sys.modules.setdefault("agents", _agents)

--- a/tests/integration/cli/test_cli_basic.py
+++ b/tests/integration/cli/test_cli_basic.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from src.main import main
+from trading_rl_agent.main import main
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/cli/test_cli_config.py
+++ b/tests/integration/cli/test_cli_config.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 import yaml
 
-from src.main import main
+from trading_rl_agent.main import main
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/cli/test_cli_entrypoint.py
+++ b/tests/integration/cli/test_cli_entrypoint.py
@@ -4,7 +4,7 @@ import runpy
 
 import pytest
 
-from src.main import main
+from trading_rl_agent.main import main
 pytestmark = pytest.mark.integration
 
 

--- a/tests/integration/cli/test_cli_errors.py
+++ b/tests/integration/cli/test_cli_errors.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from src.main import main
+from trading_rl_agent.main import main
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/cli/test_cli_tune.py
+++ b/tests/integration/cli/test_cli_tune.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from src.main import main
+from trading_rl_agent.main import main
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/test_backtester_wrapper.py
+++ b/tests/integration/test_backtester_wrapper.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from src.backtesting import Backtester
+from trading_rl_agent.backtesting import Backtester
 
 
 def test_backtester_runs_basic_strategy():

--- a/tests/integration/test_comprehensive_data_preprocessing.py
+++ b/tests/integration/test_comprehensive_data_preprocessing.py
@@ -13,7 +13,7 @@ from sklearn.preprocessing import StandardScaler
 import torch
 
 # Import data utilities
-from src.data.features import (
+from trading_rl_agent.data.features import (
     compute_adx,
     compute_atr,
     compute_bollinger_bands,
@@ -28,8 +28,8 @@ from src.data.features import (
     detect_shooting_star,
     generate_features,
 )
-from src.data.preprocessing import create_sequences
-from src.data.synthetic import fetch_synthetic_data
+from trading_rl_agent.data.preprocessing import create_sequences
+from trading_rl_agent.data.synthetic import fetch_synthetic_data
 
 
 class TestFeatureEngineering:

--- a/tests/integration/test_comprehensive_environments.py
+++ b/tests/integration/test_comprehensive_environments.py
@@ -12,7 +12,7 @@ import pandas as pd
 import pytest
 import torch
 
-from src.envs.finrl_trading_env import TradingEnv
+from trading_rl_agent.envs.finrl_trading_env import TradingEnv
 
 
 class TestEnvironmentInteractions:

--- a/tests/integration/test_data_ingestion_pipeline.py
+++ b/tests/integration/test_data_ingestion_pipeline.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from src.data_pipeline import PipelineConfig, generate_features, split_by_date
+from trading_rl_agent.data_pipeline import PipelineConfig, generate_features, split_by_date
 
 
 def test_sma_computation():

--- a/tests/integration/test_data_loader.py
+++ b/tests/integration/test_data_loader.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from src.data_pipeline import load_data
+from trading_rl_agent.data_pipeline import load_data
 
 
 def test_load_csv_parses_columns_and_dtypes(tmp_path):

--- a/tests/integration/test_data_pipeline.py
+++ b/tests/integration/test_data_pipeline.py
@@ -3,7 +3,7 @@ import pytest
 import ray
 import yaml
 
-from src.data.pipeline import run_pipeline
+from trading_rl_agent.data.pipeline import run_pipeline
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_data_pipeline_edge_cases.py
+++ b/tests/integration/test_data_pipeline_edge_cases.py
@@ -6,7 +6,7 @@ import pytest
 import ray
 import yaml
 
-from src.data.pipeline import run_pipeline
+from trading_rl_agent.data.pipeline import run_pipeline
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_data_preprocessing_comprehensive.py
+++ b/tests/integration/test_data_preprocessing_comprehensive.py
@@ -85,7 +85,7 @@ class TestDataPreprocessingComprehensive:
     def test_feature_generation_comprehensive(self, sample_market_data):
         """Test comprehensive feature generation from market data."""
         try:
-            from src.data.features import generate_features
+            from trading_rl_agent.data.features import generate_features
 
             # Test basic feature generation
             features_df = generate_features(sample_market_data.copy())
@@ -171,7 +171,7 @@ class TestDataPreprocessingComprehensive:
     def test_advanced_technical_indicators(self, sample_market_data):
         """Test advanced technical indicators."""
         try:
-            from src.data.features import (
+            from trading_rl_agent.data.features import (
                 compute_atr,
                 compute_bollinger_bands,
                 compute_ema,
@@ -239,7 +239,7 @@ class TestDataPreprocessingComprehensive:
     def test_candlestick_patterns(self, sample_market_data):
         """Test candlestick pattern detection."""
         try:
-            from src.data.features import (
+            from trading_rl_agent.data.features import (
                 detect_doji,
                 detect_engulfing,
                 detect_hammer,
@@ -293,7 +293,7 @@ class TestDataPreprocessingComprehensive:
     def test_data_normalization(self, sample_market_data):
         """Test data normalization and scaling."""
         try:
-            from src.data.features import generate_features
+            from trading_rl_agent.data.features import generate_features
 
             # Generate features first
             features_df = generate_features(sample_market_data.copy())
@@ -348,7 +348,7 @@ class TestDataPreprocessingComprehensive:
     def test_missing_data_handling(self, noisy_market_data):
         """Test handling of missing data and outliers."""
         try:
-            from src.data.features import generate_features
+            from trading_rl_agent.data.features import generate_features
 
             # Test with noisy data containing NaN values
             features_df = generate_features(noisy_market_data.copy())
@@ -392,7 +392,7 @@ class TestDataPreprocessingComprehensive:
     def test_feature_engineering_pipeline(self, sample_market_data):
         """Test complete feature engineering pipeline."""
         try:
-            from src.data.features import generate_features
+            from trading_rl_agent.data.features import generate_features
 
             # Test pipeline with different configurations
             configs = [
@@ -429,7 +429,7 @@ class TestDataPreprocessingComprehensive:
     def test_time_series_features(self, sample_market_data):
         """Test time series specific features."""
         try:
-            from src.data.features import generate_features
+            from trading_rl_agent.data.features import generate_features
 
             # Ensure timestamp column is datetime
             if "timestamp" in sample_market_data.columns:
@@ -489,7 +489,7 @@ class TestDataPreprocessingComprehensive:
         try:
             import time
 
-            from src.data.features import generate_features
+            from trading_rl_agent.data.features import generate_features
 
             initial_memory = memory_monitor["initial"]
 
@@ -531,8 +531,8 @@ class TestDataPipelineIntegration:
     def test_preprocessing_environment_integration(self, sample_market_data, tmp_path):
         """Test preprocessing integration with trading environment."""
         try:
-            from src.data.features import generate_features
-            from src.envs.finrl_trading_env import TradingEnv
+            from trading_rl_agent.data.features import generate_features
+            from trading_rl_agent.envs.finrl_trading_env import TradingEnv
 
             # Preprocess data
             features_df = generate_features(sample_market_data.copy())
@@ -570,7 +570,7 @@ class TestDataPipelineIntegration:
     def test_preprocessing_model_integration(self, sample_market_data):
         """Test preprocessing integration with predictive models."""
         try:
-            from src.data.features import generate_features
+            from trading_rl_agent.data.features import generate_features
 
             # Preprocess data
             features_df = generate_features(sample_market_data.copy())

--- a/tests/integration/test_feature_pipeline.py
+++ b/tests/integration/test_feature_pipeline.py
@@ -7,8 +7,8 @@ import pandas as pd
 import pytest
 import torch
 
-from src.data.features import generate_features
-from src.data.synthetic import generate_gbm_prices
+from trading_rl_agent.data.features import generate_features
+from trading_rl_agent.data.synthetic import generate_gbm_prices
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/test_forex_sentiment.py
+++ b/tests/integration/test_forex_sentiment.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.data.forex_sentiment import (
+from trading_rl_agent.data.forex_sentiment import (
     ForexSentimentData,
     analyze_text_sentiment,
     get_all_forex_sentiment,

--- a/tests/integration/test_historical_live.py
+++ b/tests/integration/test_historical_live.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from src.data.historical import fetch_historical_data
+from trading_rl_agent.data.historical import fetch_historical_data
 
 pytestmark = [pytest.mark.integration, pytest.mark.network, pytest.mark.slow]
 

--- a/tests/integration/test_industry_standards.py
+++ b/tests/integration/test_industry_standards.py
@@ -14,7 +14,7 @@ import pandas as pd
 import pytest
 
 # Test professional data feeds
-from src.data.professional_feeds import ProfessionalDataProvider
+from trading_rl_agent.data.professional_feeds import ProfessionalDataProvider
 
 
 class TestProfessionalDataProvider:
@@ -211,7 +211,7 @@ class TestFinRLIntegration:
 
     def test_finrl_environment_creation(self, sample_finrl_data):
         """Test FinRL environment creation."""
-        from src.envs.finrl_trading_env import HybridFinRLEnv
+        from trading_rl_agent.envs.finrl_trading_env import HybridFinRLEnv
 
         env = HybridFinRLEnv(df=sample_finrl_data)
 
@@ -222,7 +222,7 @@ class TestFinRLIntegration:
 
     def test_cnn_lstm_integration(self, sample_finrl_data):
         """Test CNN+LSTM model integration with FinRL environment."""
-        from src.envs.finrl_trading_env import HybridFinRLEnv
+        from trading_rl_agent.envs.finrl_trading_env import HybridFinRLEnv
 
         # Mock CNN+LSTM model
         mock_model = Mock()
@@ -263,7 +263,7 @@ class TestIndustryStandardMetrics:
 
     def test_sharpe_ratio_calculation(self, sample_returns):
         """Test Sharpe ratio calculation."""
-        from src.utils import metrics
+        from trading_rl_agent.utils import metrics
 
         sharpe = metrics.calculate_sharpe_ratio(sample_returns, risk_free_rate=0.02)
 
@@ -272,7 +272,7 @@ class TestIndustryStandardMetrics:
 
     def test_maximum_drawdown_calculation(self, sample_returns):
         """Test maximum drawdown calculation."""
-        from src.utils import metrics
+        from trading_rl_agent.utils import metrics
 
         max_dd = metrics.calculate_max_drawdown(sample_returns)
 
@@ -281,7 +281,7 @@ class TestIndustryStandardMetrics:
 
     def test_sortino_ratio_calculation(self, sample_returns):
         """Test Sortino ratio calculation."""
-        from src.utils import metrics
+        from trading_rl_agent.utils import metrics
 
         sortino = metrics.calculate_sortino_ratio(sample_returns, target_return=0.02)
 
@@ -290,7 +290,7 @@ class TestIndustryStandardMetrics:
 
     def test_var_calculation(self, sample_returns):
         """Test Value at Risk calculation."""
-        from src.utils import metrics
+        from trading_rl_agent.utils import metrics
 
         var_95 = metrics.calculate_var(sample_returns, confidence=0.95)
 
@@ -301,7 +301,7 @@ class TestIndustryStandardMetrics:
         self, sample_returns, sample_benchmark_returns
     ):
         """Test Information ratio calculation."""
-        from src.utils import metrics
+        from trading_rl_agent.utils import metrics
 
         info_ratio = metrics.calculate_information_ratio(
             sample_returns, sample_benchmark_returns
@@ -314,7 +314,7 @@ class TestIndustryStandardMetrics:
         self, sample_returns, sample_benchmark_returns
     ):
         """Test comprehensive metrics calculation."""
-        from src.utils import metrics
+        from trading_rl_agent.utils import metrics
 
         metrics_dict = metrics.calculate_comprehensive_metrics(
             sample_returns, sample_benchmark_returns
@@ -346,7 +346,7 @@ class TestRiskManagement:
 
     def test_position_size_calculation(self):
         """Test position sizing algorithms."""
-        from src.risk.position_sizing import IndustryGradeRiskManager
+        from trading_rl_agent.risk.position_sizing import IndustryGradeRiskManager
 
         risk_manager = IndustryGradeRiskManager(max_position_size=0.1)
 
@@ -363,7 +363,7 @@ class TestRiskManagement:
 
     def test_position_limits_enforcement(self):
         """Test position limit enforcement."""
-        from src.risk.position_sizing import IndustryGradeRiskManager
+        from trading_rl_agent.risk.position_sizing import IndustryGradeRiskManager
 
         risk_manager = IndustryGradeRiskManager(max_position_size=0.1)
 
@@ -379,7 +379,7 @@ class TestRiskManagement:
 
     def test_drawdown_monitoring(self):
         """Test maximum drawdown monitoring."""
-        from src.risk.position_sizing import IndustryGradeRiskManager
+        from trading_rl_agent.risk.position_sizing import IndustryGradeRiskManager
 
         risk_manager = IndustryGradeRiskManager(max_drawdown=0.02)
 
@@ -399,7 +399,7 @@ class TestModelServing:
     @pytest.mark.asyncio
     async def test_trading_model_service_prediction(self):
         """Test model serving prediction endpoint."""
-        from src.deployment.model_serving import TradingModelService
+        from trading_rl_agent.deployment.model_serving import TradingModelService
 
         # Mock models
         mock_cnn_lstm = Mock()
@@ -438,7 +438,7 @@ class TestModelServing:
 
     def test_model_monitoring_metrics(self):
         """Test model monitoring and metrics collection."""
-        from src.monitoring.model_monitoring import ModelMonitor
+        from trading_rl_agent.monitoring.model_monitoring import ModelMonitor
 
         monitor = ModelMonitor()
 

--- a/tests/integration/test_live_data.py
+++ b/tests/integration/test_live_data.py
@@ -9,7 +9,7 @@ import pytest
 
 pytestmark = pytest.mark.integration
 
-from src.data.live import fetch_live_data
+from trading_rl_agent.data.live import fetch_live_data
 
 
 class TestFetchLiveData:

--- a/tests/integration/test_pipeline_cached.py
+++ b/tests/integration/test_pipeline_cached.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from src.data.pipeline import load_cached_csvs
+from trading_rl_agent.data.pipeline import load_cached_csvs
 
 
 def test_load_cached_csvs_combines_files(tmp_path):

--- a/tests/integration/test_preprocessing_features.py
+++ b/tests/integration/test_preprocessing_features.py
@@ -2,8 +2,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from src.data.features import compute_bollinger_bands, compute_macd
-from src.data.preprocessing import create_sequences, preprocess_trading_data
+from trading_rl_agent.data.features import compute_bollinger_bands, compute_macd
+from trading_rl_agent.data.preprocessing import create_sequences, preprocess_trading_data
 
 
 def test_normalize_invalid_method():

--- a/tests/integration/test_ray_integration.py
+++ b/tests/integration/test_ray_integration.py
@@ -10,7 +10,7 @@ import ray
 from ray.rllib.algorithms.ppo import PPOConfig
 from ray.tune.registry import register_env
 
-from src.envs.finrl_trading_env import env_creator
+from trading_rl_agent.envs.finrl_trading_env import env_creator
 
 # Patch gym before importing the environment module
 sys.modules["gym"] = gym

--- a/tests/integration/test_serve_deployment.py
+++ b/tests/integration/test_serve_deployment.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from src.serve_deployment import PolicyDeployment, PredictorDeployment
+from trading_rl_agent.serve_deployment import PolicyDeployment, PredictorDeployment
 
 
 def test_predictor_returns_value():

--- a/tests/integration/test_td3_integration.py
+++ b/tests/integration/test_td3_integration.py
@@ -7,9 +7,9 @@ import numpy as np
 import pytest
 import torch
 
-from src.agents.configs import TD3Config
-from src.agents.td3_agent import TD3Agent
-from src.envs.finrl_trading_env import TradingEnv
+from trading_rl_agent.agents.configs import TD3Config
+from trading_rl_agent.agents.td3_agent import TD3Agent
+from trading_rl_agent.envs.finrl_trading_env import TradingEnv
 
 pytestmark = pytest.mark.integration
 
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.integration
 @pytest.fixture
 def td3_config():
     """Create TD3 config optimized for integration testing."""
-    from src.agents.configs import TD3Config
+    from trading_rl_agent.agents.configs import TD3Config
 
     return TD3Config(
         learning_rate=1e-3,

--- a/tests/integration/test_trading_env.py
+++ b/tests/integration/test_trading_env.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from src.envs.finrl_trading_env import TradingEnv, env_creator, register_env
+from trading_rl_agent.envs.finrl_trading_env import TradingEnv, env_creator, register_env
 
 
 @pytest.fixture

--- a/tests/integration/test_trading_env_additional.py
+++ b/tests/integration/test_trading_env_additional.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from src.envs.finrl_trading_env import TradingEnv
+from trading_rl_agent.envs.finrl_trading_env import TradingEnv
 
 
 def make_env(tmp_path, **overrides):

--- a/tests/integration/test_trading_env_model_integration.py
+++ b/tests/integration/test_trading_env_model_integration.py
@@ -3,8 +3,8 @@ import pandas as pd
 import pytest
 import torch
 
-from src.envs.finrl_trading_env import TradingEnv
-from src.supervised_model import ModelConfig, TrendPredictor, save_model
+from trading_rl_agent.envs.finrl_trading_env import TradingEnv
+from trading_rl_agent.supervised_model import ModelConfig, TrendPredictor, save_model
 
 pytestmark = pytest.mark.integration
 

--- a/tests/integration/test_tune.py
+++ b/tests/integration/test_tune.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 import yaml
 
-from src.agents.tune import _convert_value, _load_search_space, run_tune
+from trading_rl_agent.agents.tune import _convert_value, _load_search_space, run_tune
 
 
 class TestConvertValue:

--- a/tests/integration/test_yfinance_missing.py
+++ b/tests/integration/test_yfinance_missing.py
@@ -1,7 +1,7 @@
 import pytest
 
-from src.data.historical import fetch_historical_data
-from src.data.live import fetch_live_data
+from trading_rl_agent.data.historical import fetch_historical_data
+from trading_rl_agent.data.live import fetch_live_data
 
 
 def test_fetch_historical_data_missing_yfinance(monkeypatch):

--- a/tests/performance/test_cnn_lstm_optimization.py
+++ b/tests/performance/test_cnn_lstm_optimization.py
@@ -5,8 +5,8 @@ import numpy as np
 import pytest
 import torch
 
-from src.optimization import cnn_lstm_optimization as mod
-from src.optimization.cnn_lstm_optimization import (
+from trading_rl_agent.optimization import cnn_lstm_optimization as mod
+from trading_rl_agent.optimization.cnn_lstm_optimization import (
     create_simple_dataset,
     get_default_search_space,
     optimize_cnn_lstm_streamlined,

--- a/tests/performance/test_cnn_lstm_optimization_ray.py
+++ b/tests/performance/test_cnn_lstm_optimization_ray.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 import torch
 
-from src.optimization import cnn_lstm_optimization as mod
+from trading_rl_agent.optimization import cnn_lstm_optimization as mod
 
 
 def test_ray_tune_optimization_unavailable(monkeypatch):

--- a/tests/performance/test_optimization.py
+++ b/tests/performance/test_optimization.py
@@ -19,8 +19,8 @@ from ray import tune
 import torch
 import torch.nn as nn
 
-from src.models.cnn_lstm import CNNLSTMModel
-from src.optimization.model_utils import (
+from trading_rl_agent.models.cnn_lstm import CNNLSTMModel
+from trading_rl_agent.optimization.model_utils import (
     detect_gpus,
     get_model_summary,
     optimal_gpu_config,
@@ -229,10 +229,10 @@ class TestHyperparamOptimization:
 
     def test_hyperparameter_search_space(self):
         """Test hyperparameter search space conversion for Ray Tune."""
-        from src.optimization.cnn_lstm_optimization import (
+        from trading_rl_agent.optimization.cnn_lstm_optimization import (
             get_default_search_space,
         )
-        from src.optimization.rl_optimization import _get_default_sac_search_space
+        from trading_rl_agent.optimization.rl_optimization import _get_default_sac_search_space
 
         # Test CNN-LSTM search space
         cnn_lstm_space = get_default_search_space()

--- a/tests/performance/test_optimization_utils.py
+++ b/tests/performance/test_optimization_utils.py
@@ -1,6 +1,6 @@
 import types
 
-import src.optimization.model_utils as mu
+import trading_rl_agent.optimization.model_utils as mu
 
 
 def test_optimal_gpu_config_no_gpu(monkeypatch):

--- a/tests/performance/test_streamlined_optimization.py
+++ b/tests/performance/test_streamlined_optimization.py
@@ -16,7 +16,7 @@ def test_optimization():
     print("🧪 Testing streamlined optimization...")
 
     try:
-        from src.optimization import optimize_cnn_lstm
+        from trading_rl_agent.optimization import optimize_cnn_lstm
 
         # Test with small data
         np.random.seed(42)

--- a/tests/performance/test_train_cnn_lstm.py
+++ b/tests/performance/test_train_cnn_lstm.py
@@ -14,8 +14,8 @@ import torch
 
 import yaml
 
-from src.models.cnn_lstm import CNNLSTMModel
-from src.training.cnn_lstm import (
+from trading_rl_agent.models.cnn_lstm import CNNLSTMModel
+from trading_rl_agent.training.cnn_lstm import (
     CNNLSTMTrainer,
     TrainingConfig,
     create_example_config,

--- a/tests/performance/test_train_cnn_lstm_forex.py
+++ b/tests/performance/test_train_cnn_lstm_forex.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from src.training.cnn_lstm import CNNLSTMTrainer, TrainingConfig
+from trading_rl_agent.training.cnn_lstm import CNNLSTMTrainer, TrainingConfig
 
 
 class DummySentimentAnalyzer:

--- a/tests/performance/test_trainer.py
+++ b/tests/performance/test_trainer.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 import yaml
 
-from src.agents.trainer import Trainer
+from trading_rl_agent.agents.trainer import Trainer
 
 
 @pytest.fixture

--- a/tests/unit/test_cached_data.py
+++ b/tests/unit/test_cached_data.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from src.data.pipeline import load_cached_csvs
+from trading_rl_agent.data.pipeline import load_cached_csvs
 
 
 def test_load_cached_csvs(tmp_path):

--- a/tests/unit/test_candle_patterns.py
+++ b/tests/unit/test_candle_patterns.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from src.data.candle_patterns import (
+from trading_rl_agent.data.candle_patterns import (
     compute_candle_stats,
     detect_dark_cloud_cover,
     detect_harami,
@@ -20,14 +20,14 @@ from src.data.candle_patterns import (
 )
 
 # Import the original functions to compare with advanced patterns
-from src.data.features import detect_doji
-from src.data.features import detect_doji as features_detect_doji
-from src.data.features import detect_engulfing
-from src.data.features import detect_engulfing as features_detect_engulfing
-from src.data.features import detect_evening_star
-from src.data.features import detect_hammer
-from src.data.features import detect_hammer as features_detect_hammer
-from src.data.features import detect_morning_star, detect_shooting_star
+from trading_rl_agent.data.features import detect_doji
+from trading_rl_agent.data.features import detect_doji as features_detect_doji
+from trading_rl_agent.data.features import detect_engulfing
+from trading_rl_agent.data.features import detect_engulfing as features_detect_engulfing
+from trading_rl_agent.data.features import detect_evening_star
+from trading_rl_agent.data.features import detect_hammer
+from trading_rl_agent.data.features import detect_hammer as features_detect_hammer
+from trading_rl_agent.data.features import detect_morning_star, detect_shooting_star
 
 
 def create_test_df():
@@ -319,7 +319,7 @@ def test_complex_pattern_combination():
     )
 
     # Apply all pattern detection functions
-    from src.data.candle_patterns import compute_all_candle_patterns
+    from trading_rl_agent.data.candle_patterns import compute_all_candle_patterns
 
     result = compute_all_candle_patterns(df)
 

--- a/tests/unit/test_cli_args.py
+++ b/tests/unit/test_cli_args.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.main import build_parser
+from trading_rl_agent.main import build_parser
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_cluster_utils.py
+++ b/tests/unit/test_cluster_utils.py
@@ -2,7 +2,7 @@ import types
 
 import ray
 
-from src.utils.cluster import get_available_devices, init_ray
+from trading_rl_agent.utils.cluster import get_available_devices, init_ray
 
 
 def test_get_available_devices(monkeypatch):

--- a/tests/unit/test_cnn_lstm.py
+++ b/tests/unit/test_cnn_lstm.py
@@ -1,6 +1,6 @@
 import torch
 
-from src.models import CNNLSTMModel
+from trading_rl_agent.models import CNNLSTMModel
 
 
 def test_model_instantiation_from_yaml():

--- a/tests/unit/test_cnn_lstm_additional.py
+++ b/tests/unit/test_cnn_lstm_additional.py
@@ -2,7 +2,7 @@ import yaml
 import torch
 import pytest
 
-from src.models.cnn_lstm import CNNLSTMModel, _load_config
+from trading_rl_agent.models.cnn_lstm import CNNLSTMModel, _load_config
 
 
 def test_load_config_from_path(tmp_path):

--- a/tests/unit/test_cnn_lstm_model_more.py
+++ b/tests/unit/test_cnn_lstm_model_more.py
@@ -2,7 +2,7 @@ import torch
 import yaml
 import pytest
 
-from src.models import CNNLSTMModel
+from trading_rl_agent.models import CNNLSTMModel
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_concat_model.py
+++ b/tests/unit/test_concat_model.py
@@ -2,7 +2,7 @@ from gymnasium import spaces
 import numpy as np
 import torch
 
-from src.models.concat_model import ConcatModel
+from trading_rl_agent.models.concat_model import ConcatModel
 
 
 def test_concat_model_output_shape():

--- a/tests/unit/test_dataclasses_trainer.py
+++ b/tests/unit/test_dataclasses_trainer.py
@@ -4,8 +4,8 @@ from unittest import mock
 
 import pytest
 
-from src.agents import trainer as trainer_module
-from src.agents.configs import EnsembleConfig
+from trading_rl_agent.agents import trainer as trainer_module
+from trading_rl_agent.agents.configs import EnsembleConfig
 
 
 def test_ensemble_config_alias_and_validation():

--- a/tests/unit/test_env_resets.py
+++ b/tests/unit/test_env_resets.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from src.envs.finrl_trading_env import TradingEnv
+from trading_rl_agent.envs.finrl_trading_env import TradingEnv
 
 
 def create_env(tmp_path):

--- a/tests/unit/test_features.py
+++ b/tests/unit/test_features.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 from ta.momentum import RSIIndicator
 
-from src.data.features import add_sentiment, generate_features
+from trading_rl_agent.data.features import add_sentiment, generate_features
 
 
 def test_compute_log_returns():

--- a/tests/unit/test_metrics_additional.py
+++ b/tests/unit/test_metrics_additional.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from src.utils import metrics
+from trading_rl_agent.utils import metrics
 
 
 def test_var_and_expected_shortfall():

--- a/tests/unit/test_metrics_basic.py
+++ b/tests/unit/test_metrics_basic.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from src.utils import metrics
+from trading_rl_agent.utils import metrics
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_metrics_calculations_new.py
+++ b/tests/unit/test_metrics_calculations_new.py
@@ -3,7 +3,7 @@ import pandas as pd
 import quantstats.stats as qs
 import pytest
 
-from src.utils import metrics
+from trading_rl_agent.utils import metrics
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_nlp_sentiment.py
+++ b/tests/unit/test_nlp_sentiment.py
@@ -4,10 +4,10 @@ from unittest.mock import patch
 import pandas as pd
 import pytest
 
-from src.data.features import generate_features
-from src.data.sentiment import SentimentData
-from src.data.synthetic import generate_gbm_prices
-from src.nlp import (
+from trading_rl_agent.data.features import generate_features
+from trading_rl_agent.data.sentiment import SentimentData
+from trading_rl_agent.data.synthetic import generate_gbm_prices
+from trading_rl_agent.nlp import (
     get_sentiment_scores,
     score_news_sentiment,
     score_social_sentiment,

--- a/tests/unit/test_pipeline_helpers.py
+++ b/tests/unit/test_pipeline_helpers.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from src.data.pipeline import load_cached_csvs
+from trading_rl_agent.data.pipeline import load_cached_csvs
 
 
 def test_load_cached_csvs_empty(tmp_path):

--- a/tests/unit/test_pipeline_load_cached_csvs_new.py
+++ b/tests/unit/test_pipeline_load_cached_csvs_new.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from src.data.pipeline import load_cached_csvs
+from trading_rl_agent.data.pipeline import load_cached_csvs
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_quantstats_metrics.py
+++ b/tests/unit/test_quantstats_metrics.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import quantstats.stats as qs
 
-from src.utils import metrics
+from trading_rl_agent.utils import metrics
 
 
 def _sample_series():

--- a/tests/unit/test_reward_calculation.py
+++ b/tests/unit/test_reward_calculation.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-from src.envs.finrl_trading_env import TradingEnv
+from trading_rl_agent.envs.finrl_trading_env import TradingEnv
 
 
 def make_env(tmp_path, closes, tc=0.1):

--- a/tests/unit/test_riskfolio_risk_manager.py
+++ b/tests/unit/test_riskfolio_risk_manager.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from src.risk import RiskfolioConfig, RiskfolioRiskManager
+from trading_rl_agent.risk import RiskfolioConfig, RiskfolioRiskManager
 
 
 @pytest.fixture

--- a/tests/unit/test_sentiment.py
+++ b/tests/unit/test_sentiment.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.data.sentiment import (
+from trading_rl_agent.data.sentiment import (
     NewsSentimentProvider,
     SentimentAnalyzer,
     SentimentConfig,
@@ -243,7 +243,7 @@ class TestSentimentIntegration:
 
     def test_sentiment_with_global_dict_backward_compatibility(self):
         """Test that global sentiment dict is updated for backward compatibility."""
-        from src.data import sentiment
+        from trading_rl_agent.data import sentiment
 
         analyzer = SentimentAnalyzer()
         analyzer.fetch_all_sentiment("META", days_back=1)
@@ -281,7 +281,7 @@ class TestSentimentIntegration:
     def test_sentiment_error_handling(self):
         """Test sentiment provider error handling."""
         # Test with provider that raises exception
-        from src.data.sentiment import SentimentProvider
+        from trading_rl_agent.data.sentiment import SentimentProvider
 
         class FailingProvider(SentimentProvider):
             def fetch_sentiment(self, symbol, days_back=1):

--- a/tests/unit/test_setup_utils.py
+++ b/tests/unit/test_setup_utils.py
@@ -4,9 +4,9 @@ Test setup utilities for integration tests.
 
 import numpy as np
 
-from src.agents.configs import TD3Config
-from src.agents.td3_agent import TD3Agent
-from src.envs.finrl_trading_env import TradingEnv
+from trading_rl_agent.agents.configs import TD3Config
+from trading_rl_agent.agents.td3_agent import TD3Agent
+from trading_rl_agent.envs.finrl_trading_env import TradingEnv
 from tests.unit.test_data_utils import TestDataManager, get_dynamic_test_config
 
 

--- a/tests/unit/test_supervised_model.py
+++ b/tests/unit/test_supervised_model.py
@@ -5,7 +5,7 @@ import pytest
 import ray
 import torch
 
-from src.supervised_model import (
+from trading_rl_agent.supervised_model import (
     ModelConfig,
     TrainingConfig,
     TrendPredictor,
@@ -15,7 +15,7 @@ from src.supervised_model import (
     save_model,
     select_best_model,
 )
-from src.supervised_model import train_supervised  # Use Ray remote version
+from trading_rl_agent.supervised_model import train_supervised  # Use Ray remote version
 
 # Configure logging
 logging.basicConfig(

--- a/tests/unit/test_supervised_model_utils.py
+++ b/tests/unit/test_supervised_model_utils.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 import torch
 
-from src.supervised_model import (
+from trading_rl_agent.supervised_model import (
     ModelConfig,
     TrendPredictor,
     _to_tensor,

--- a/tests/unit/test_synthetic_data.py
+++ b/tests/unit/test_synthetic_data.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from src.data.synthetic import fetch_synthetic_data
+from trading_rl_agent.data.synthetic import fetch_synthetic_data
 
 
 def test_synthetic_columns_and_length():

--- a/tests/unit/test_ta_features.py
+++ b/tests/unit/test_ta_features.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 from ta.volume import OnBalanceVolumeIndicator
 
-from src.data.features import (
+from trading_rl_agent.data.features import (
     compute_adx,
     compute_atr,
     compute_bollinger_bands,

--- a/tests/unit/test_td3_agent.py
+++ b/tests/unit/test_td3_agent.py
@@ -12,9 +12,9 @@ import pytest
 import torch
 import torch.nn as nn
 
-from src.agents.configs import TD3Config
-from src.agents.td3_agent import TD3Agent
-from src.envs.finrl_trading_env import TradingEnv
+from trading_rl_agent.agents.configs import TD3Config
+from trading_rl_agent.agents.td3_agent import TD3Agent
+from trading_rl_agent.envs.finrl_trading_env import TradingEnv
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_trading_env_basic.py
+++ b/tests/unit/test_trading_env_basic.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from src.envs.finrl_trading_env import TradingEnv
+from trading_rl_agent.envs.finrl_trading_env import TradingEnv
 
 
 def make_env(tmp_path, reward_type="profit"):

--- a/tests/unit/test_trading_env_reset_step_new.py
+++ b/tests/unit/test_trading_env_reset_step_new.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from src.envs.finrl_trading_env import TradingEnv
+from trading_rl_agent.envs.finrl_trading_env import TradingEnv
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_trainer_basic.py
+++ b/tests/unit/test_trainer_basic.py
@@ -1,7 +1,7 @@
 import types
 from unittest import mock
 
-from src.agents import trainer as trainer_module
+from trading_rl_agent.agents import trainer as trainer_module
 
 
 def test_trainer_defaults(monkeypatch, tmp_path):

--- a/tests/unit/test_trainer_loops.py
+++ b/tests/unit/test_trainer_loops.py
@@ -1,7 +1,7 @@
 import types
 from unittest import mock
 
-from src.agents import trainer as trainer_module
+from trading_rl_agent.agents import trainer as trainer_module
 
 
 def test_dqn_algorithm_selected(monkeypatch, tmp_path):

--- a/tests/unit/test_trainer_minimal_loops.py
+++ b/tests/unit/test_trainer_minimal_loops.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock, patch
 import types
 import pytest
 
-from src.agents import trainer as trainer_module
+from trading_rl_agent.agents import trainer as trainer_module
 
 pytestmark = pytest.mark.unit
 


### PR DESCRIPTION
## Summary
- switch imports from `src` to `trading_rl_agent`
- keep docs and tests updated for the new package name

## Testing
- `PYTHONPATH=$PWD/src pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog')*

------
https://chatgpt.com/codex/tasks/task_e_686c99f07648832eaa9d850e4dee1a6b