### PR TITLE
Use ConfigManager for environment configs

### DIFF
--- a/configs/development.yaml
+++ b/configs/development.yaml
@@ -1,0 +1,18 @@
+environment: development
+debug: true
+
+data:
+  data_path: data/dev.csv
+  feature_window: 30
+  real_time_enabled: false
+
+model:
+  model_save_path: models/dev_model.pth
+
+agent:
+  agent_type: sac
+  total_timesteps: 10000
+
+monitoring:
+  log_level: DEBUG
+  mlflow_enabled: false

--- a/configs/production.yaml
+++ b/configs/production.yaml
@@ -1,0 +1,29 @@
+environment: production
+debug: false
+
+data:
+  data_sources:
+    primary: alpaca
+    backup: yfinance
+  real_time_enabled: true
+  feature_window: 50
+
+agent:
+  agent_type: sac
+  ensemble_size: 3
+  total_timesteps: 1000000
+
+risk:
+  max_position_size: 0.1
+  max_leverage: 1.0
+  var_confidence_level: 0.05
+
+execution:
+  broker: alpaca
+  paper_trading: false
+  order_timeout: 60
+
+monitoring:
+  mlflow_enabled: true
+  alerts_enabled: true
+  metrics_frequency: 300

--- a/configs/staging.yaml
+++ b/configs/staging.yaml
@@ -1,0 +1,18 @@
+environment: staging
+debug: false
+
+data:
+  data_path: data/stage.csv
+  feature_window: 40
+  real_time_enabled: true
+
+model:
+  model_save_path: models/stage_model.pth
+
+agent:
+  agent_type: sac
+  total_timesteps: 500000
+
+monitoring:
+  log_level: INFO
+  mlflow_enabled: true

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ import psutil
 import yaml
 
 from trading_rl_agent.agents.trainer import Trainer
+from trading_rl_agent.core.config import ConfigManager
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -15,13 +16,27 @@ def build_parser() -> argparse.ArgumentParser:
         description="Train or evaluate an RL trading agent"
     )
     parser.add_argument(
-        "--env-config", type=str, required=True, help="Path to environment config YAML"
+        "--config",
+        type=str,
+        help="Path to unified system config YAML",
     )
     parser.add_argument(
-        "--model-config", type=str, required=True, help="Path to model config YAML"
+        "--env-config",
+        type=str,
+        required=False,
+        help="Path to environment config YAML",
     )
     parser.add_argument(
-        "--trainer-config", type=str, required=True, help="Path to trainer config YAML"
+        "--model-config",
+        type=str,
+        required=False,
+        help="Path to model config YAML",
+    )
+    parser.add_argument(
+        "--trainer-config",
+        type=str,
+        required=False,
+        help="Path to trainer config YAML",
     )
     parser.add_argument("--seed", type=int, default=42, help="Random seed")
     parser.add_argument(
@@ -48,16 +63,26 @@ def main(argv: list[str] | None = None) -> None:
     if args.tune:
         from agents.tune import run_tune
 
-        run_tune([args.env_config, args.model_config, args.trainer_config])
+        if args.config:
+            run_tune(args.config)
+        else:
+            run_tune([args.env_config, args.model_config, args.trainer_config])
         return
 
-    # Load configurations
-    with open(args.env_config) as f:
-        env_cfg = yaml.safe_load(f)
-    with open(args.model_config) as f:
-        model_cfg = yaml.safe_load(f)
-    with open(args.trainer_config) as f:
-        trainer_cfg = yaml.safe_load(f)
+    if args.config:
+        cfg_mgr = ConfigManager(args.config)
+        system_cfg = cfg_mgr.load_config()
+        env_cfg = system_cfg.data.__dict__
+        model_cfg = system_cfg.model.__dict__
+        trainer_cfg = system_cfg.rl.__dict__
+    else:
+        # Legacy separate configs
+        with open(args.env_config) as f:
+            env_cfg = yaml.safe_load(f)
+        with open(args.model_config) as f:
+            model_cfg = yaml.safe_load(f)
+        with open(args.trainer_config) as f:
+            trainer_cfg = yaml.safe_load(f)
 
     trainer = Trainer(
         env_cfg, model_cfg, trainer_cfg, seed=args.seed, save_dir=args.save_dir

--- a/src/training/cnn_lstm.py
+++ b/src/training/cnn_lstm.py
@@ -528,34 +528,11 @@ class CNNLSTMTrainer:
 # Example training configuration
 def create_example_config() -> str:
     """Create an example training configuration file."""
-    config = {
-        "data": {
-            "source": {"type": "csv", "path": "data/sample_data.csv"},
-            "symbols": ["AAPL", "GOOGL", "TSLA"],
-        },
-        "training": {
-            "sequence_length": 60,
-            "prediction_horizon": 1,
-            "learning_rate": 0.001,
-            "batch_size": 32,
-            "epochs": 100,
-            "include_sentiment": True,
-            "use_attention": True,
-            "model_config": {
-                "cnn_filters": [64, 128],
-                "cnn_kernel_sizes": [3, 5],
-                "lstm_units": 256,
-                "dropout": 0.2,
-            },
-        },
-    }
-
+    config_mgr = ConfigManager()
+    cfg = config_mgr.get_config()
     config_path = "src/configs/training/cnn_lstm_train.yaml"
     os.makedirs(os.path.dirname(config_path), exist_ok=True)
-
-    with open(config_path, "w") as f:
-        yaml.safe_dump(config, f, default_flow_style=False)
-
+    config_mgr.save_config(cfg, config_path)
     return config_path
 
 

--- a/src/training/rl.py
+++ b/src/training/rl.py
@@ -11,6 +11,7 @@ from ray.rllib.models import ModelCatalog
 from trading_rl_agent.envs.finrl_trading_env import TradingEnv, register_env
 from trading_rl_agent.models.concat_model import ConcatModel
 from trading_rl_agent.utils.cluster import get_available_devices, init_ray
+from trading_rl_agent.core.config import ConfigManager
 
 
 def create_env(cfg):
@@ -20,12 +21,16 @@ def create_env(cfg):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--data", type=str, required=True, help="CSV file with market data"
+        "--config",
+        type=str,
+        help="Path to system config YAML",
+    )
+    parser.add_argument(
+        "--data", type=str, help="CSV file with market data"
     )
     parser.add_argument(
         "--model-path",
         type=str,
-        required=True,
         help="Path to supervised model checkpoint",
     )
     parser.add_argument("--num-workers", type=int, default=0)
@@ -44,16 +49,31 @@ def main():
 
     init_ray(config_path=args.cluster_config, local_mode=args.local_mode)
     resources = get_available_devices()
-    if args.num_workers == 0:
-        # use all CPUs minus one for the driver
-        args.num_workers = max(1, int(resources["CPU"] - 1))
-    if args.num_gpus == 0 and resources.get("GPU", 0) > 0:
-        args.num_gpus = int(resources["GPU"])
+
+    if args.config:
+        cfg_mgr = ConfigManager(args.config)
+        cfg = cfg_mgr.load_config()
+        data_path = args.data or cfg.data.data_path
+        model_path = args.model_path or cfg.model.model_save_path
+        if args.num_workers == 0:
+            args.num_workers = cfg.infrastructure.num_workers
+        if args.num_gpus == 0:
+            args.num_gpus = resources.get("GPU", 0) if cfg.infrastructure.gpu_enabled else 0
+        window_size = cfg.data.feature_window
+    else:
+        if args.num_workers == 0:
+            # use all CPUs minus one for the driver
+            args.num_workers = max(1, int(resources["CPU"] - 1))
+        if args.num_gpus == 0 and resources.get("GPU", 0) > 0:
+            args.num_gpus = int(resources["GPU"])
+        data_path = args.data
+        model_path = args.model_path
+        window_size = 50
 
     env_config = {
-        "dataset_paths": [args.data],
-        "window_size": 50,
-        "model_path": args.model_path,
+        "dataset_paths": [data_path],
+        "window_size": window_size,
+        "model_path": model_path,
     }
 
     register_env("TradingEnvRL", lambda cfg: create_env(cfg))


### PR DESCRIPTION
## Summary
- support unified config loading in `src/main.py`
- allow RL trainer to read settings from ConfigManager
- use ConfigManager when generating CNN-LSTM example configs
- add sample YAML configs for dev, staging and production environments

## Testing
- `pip install -q -r requirements.txt`
- `pip install -e .`
- `pytest -m unit -q` *(fails: ModuleNotFoundError: No module named 'trading_rl_agent')*

------
https://chatgpt.com/codex/tasks/task_e_686d1a387ef0832ea0990497cbd818ef