### PR TITLE
Implement risk metrics utilities and tests

### DIFF
--- a/src/trading_rl_agent/risk/__init__.py
+++ b/src/trading_rl_agent/risk/__init__.py
@@ -9,13 +9,9 @@ Provides comprehensive risk management including:
 """
 
 from .manager import RiskManager
-from .var_calculator import VaRCalculator
-from .position_sizer import PositionSizer
-from .monitors import RiskMonitor
+from .position_sizer import kelly_position_size
 
 __all__ = [
     "RiskManager",
-    "VaRCalculator",
-    "PositionSizer",
-    "RiskMonitor",
+    "kelly_position_size",
 ]

--- a/src/trading_rl_agent/risk/position_sizer.py
+++ b/src/trading_rl_agent/risk/position_sizer.py
@@ -1,0 +1,36 @@
+"""Position sizing utilities."""
+
+from __future__ import annotations
+
+
+def kelly_position_size(
+    expected_return: float,
+    win_rate: float,
+    avg_win: float,
+    avg_loss: float,
+    max_kelly_fraction: float = 0.25,
+) -> float:
+    """Return Kelly criterion position size fraction.
+
+    Parameters
+    ----------
+    expected_return : float
+        Expected return of the strategy (unused but kept for API compatibility).
+    win_rate : float
+        Historical probability of a winning trade between 0 and 1.
+    avg_win : float
+        Average profit of winning trades.
+    avg_loss : float
+        Average loss of losing trades (positive value).
+    max_kelly_fraction : float, optional
+        Maximum fraction of capital to risk, by default 0.25.
+    """
+    if avg_loss <= 0 or win_rate <= 0 or win_rate >= 1:
+        return 0.0
+
+    b = avg_win / avg_loss
+    p = win_rate
+    q = 1 - win_rate
+    kelly_fraction = (b * p - q) / b
+    kelly_fraction = max(0.0, kelly_fraction)
+    return min(kelly_fraction, max_kelly_fraction)


### PR DESCRIPTION
## Summary
- extend RiskManager with portfolio drawdown calculation and drawdown limit checks
- expose Kelly position sizing via new `position_sizer` module and clean `risk` package API
- update concentration risk computation
- add unit tests covering drawdown and module-level Kelly function

## Testing
- `pytest -q tests/unit/test_risk_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_686d26adb3cc832e8108ffd168c92e30