### PR TITLE
Add missing requirements-test.txt

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -14,11 +14,8 @@ pip install -r requirements-test.txt
 `nltk>=3.8` is included in the base requirements and is required for the
 sentiment analysis tests.
 
-For machine-learning features (PyTorch and RLlib) install additional packages:
-
-```bash
-pip install -r requirements-ml.txt
-```
+The `requirements-test.txt` file already bundles PyTorch and Ray RLlib so no
+extra ML file is needed.
 
 The optional file `requirements-test-comprehensive.txt` provides extra plugins for the full coverage suite:
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,7 +10,7 @@ torch>=1.12.0,<2.3.0
 ray[rllib]>=2.31.0,<2.47.0
 gymnasium>=0.29.1,<1.2.0
 stable-baselines3>=1.7.0,<2.0.0
-sb3-contrib>=1.7.0
+sb3-contrib>=1.7.0,<2.0.0
 
 # Pytest and useful plugins
 pytest>=7.4.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,23 @@
+# Trading RL Agent - Test Requirements
+
+# Core numerical & ML libraries
+numpy>=1.21.0,<2.0.0
+pandas>=1.5.0,<2.2.0
+scipy>=1.7.0,<1.12.0
+torch>=1.12.0,<2.3.0
+
+# Reinforcement learning frameworks
+ray[rllib]>=2.31.0,<2.47.0
+gymnasium>=0.29.1,<1.2.0
+stable-baselines3>=1.7.0
+sb3-contrib>=1.7.0
+
+# Pytest and useful plugins
+pytest>=7.4.0
+pytest-cov>=4.1.0
+pytest-mock>=3.11.0
+pytest-xdist>=3.3.0
+pytest-asyncio>=0.21.0
+pytest-timeout>=2.1.0
+pytest-benchmark>=4.0.0
+faker>=13.0.0,<25.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,7 +9,7 @@ torch>=1.12.0,<2.3.0
 # Reinforcement learning frameworks
 ray[rllib]>=2.31.0,<2.47.0
 gymnasium>=0.29.1,<1.2.0
-stable-baselines3>=1.7.0
+stable-baselines3>=1.7.0,<2.0.0
 sb3-contrib>=1.7.0
 
 # Pytest and useful plugins


### PR DESCRIPTION
## Summary
- add requirements-test.txt containing pytest plugins and ML/RL packages
- document usage of requirements-test.txt in TESTING.md

## Testing
- `pytest -k "" tests` *(fails: ModuleNotFoundError: No module named 'trading_rl_agent')*

------
https://chatgpt.com/codex/tasks/task_e_686d9e02f710832eae1b8952c50e6f9d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to clarify that all necessary machine learning packages are included in the main testing requirements file, removing the need for a separate ML requirements file.

* **Chores**
  * Added a new requirements file specifying all dependencies needed for testing, including machine learning libraries and testing tools, with explicit version constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->