### PR TITLE
Implement lazy loading in package init

### DIFF
--- a/src/trading_rl_agent/__init__.py
+++ b/src/trading_rl_agent/__init__.py
@@ -51,6 +51,19 @@ __all__ = [
 ]
 
 
+def __dir__():
+    """Return a list of attributes for tab completion."""
+    lazy_keys = [
+        "Agent",
+        "EnsembleAgent",
+        "Trainer",
+        "DataPipeline",
+        "MarketDataLoader",
+        "PortfolioManager",
+        "RiskManager",
+        "ExecutionEngine",
+    ]
+    return sorted(__all__ + lazy_keys)
 def __getattr__(name: str):
     """Lazily import heavy optional components when accessed."""
     import importlib

--- a/src/trading_rl_agent/__init__.py
+++ b/src/trading_rl_agent/__init__.py
@@ -64,24 +64,24 @@ def __dir__():
         "ExecutionEngine",
     ]
     return sorted(__all__ + lazy_keys)
+# Mapping of lazily imported components to their modules and attributes
+lazy_map = {
+    # Agents and trainer related components
+    "Agent": (".agents", "Agent"),
+    "EnsembleAgent": (".agents", "EnsembleAgent"),
+    "Trainer": (".agents.trainer", "Trainer"),
+    # Data handling
+    "DataPipeline": (".data", "DataPipeline"),
+    "MarketDataLoader": (".data", "MarketDataLoader"),
+    # Portfolio, risk and execution modules
+    "PortfolioManager": (".portfolio", "PortfolioManager"),
+    "RiskManager": (".risk", "RiskManager"),
+    "ExecutionEngine": (".execution", "ExecutionEngine"),
+}
+
 def __getattr__(name: str):
     """Lazily import heavy optional components when accessed."""
     import importlib
-
-    lazy_map = {
-        # Agents and trainer related components
-        "Agent": (".agents", "Agent"),
-        "EnsembleAgent": (".agents", "EnsembleAgent"),
-        "Trainer": (".agents.trainer", "Trainer"),
-        # Data handling
-        "DataPipeline": (".data", "DataPipeline"),
-        "MarketDataLoader": (".data", "MarketDataLoader"),
-        # Portfolio, risk and execution modules
-        "PortfolioManager": (".portfolio", "PortfolioManager"),
-        "RiskManager": (".risk", "RiskManager"),
-        "ExecutionEngine": (".execution", "ExecutionEngine"),
-    }
-
     if name in lazy_map:
         module_name, attr = lazy_map[name]
         try:


### PR DESCRIPTION
## Summary
- avoid importing heavy ML modules when importing `trading_rl_agent`
- load Agent, Trainer and other optional components on demand

## Testing
- `pytest -m unit tests/unit/test_package_imports.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686da2a48778832ebbcf74b8c86e664d