### PR TITLE
Add feature pipeline

### DIFF
--- a/src/trading_rl_agent/features/alternative_data.py
+++ b/src/trading_rl_agent/features/alternative_data.py
@@ -1,0 +1,38 @@
+"""Alternative data feature calculations."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import pandas as pd
+
+from ..core.logging import get_logger
+
+
+@dataclass
+class AlternativeDataConfig:
+    """Configuration for alternative data features."""
+
+    sentiment_column: str = "news_sentiment"
+
+
+class AlternativeDataFeatures:
+    """Attach alternative data such as sentiment scores."""
+
+    def __init__(self, config: Optional[AlternativeDataConfig] = None) -> None:
+        self.config = config or AlternativeDataConfig()
+        self.logger = get_logger(self.__class__.__name__)
+
+    def add_alternative_features(
+        self, df: pd.DataFrame, sentiment: Optional[pd.Series] = None
+    ) -> pd.DataFrame:
+        result = df.copy()
+        col = self.config.sentiment_column
+        if sentiment is not None:
+            result[col] = sentiment.reset_index(drop=True).iloc[: len(result)]
+        else:
+            result[col] = 0.0
+        return result
+
+    def get_feature_names(self) -> list[str]:
+        """Return names of generated alternative data features."""
+        return [self.config.sentiment_column]

--- a/src/trading_rl_agent/features/cross_asset.py
+++ b/src/trading_rl_agent/features/cross_asset.py
@@ -1,0 +1,44 @@
+"""Cross-asset correlation feature calculations."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from ..core.logging import get_logger
+
+
+@dataclass
+class CrossAssetConfig:
+    """Configuration for cross-asset features."""
+
+    corr_window: int = 5
+    prefix: str = "bench"
+
+
+class CrossAssetFeatures:
+    """Compute rolling correlation with a reference asset."""
+
+    def __init__(self, config: Optional[CrossAssetConfig] = None) -> None:
+        self.config = config or CrossAssetConfig()
+        self.logger = get_logger(self.__class__.__name__)
+
+    def add_cross_asset_features(
+        self, df: pd.DataFrame, reference: pd.DataFrame
+    ) -> pd.DataFrame:
+        """Add rolling correlation of ``df`` with ``reference``."""
+        result = df.copy()
+        ref_close = reference["close"].reset_index(drop=True).iloc[: len(result)]
+        result["_ref_close"] = ref_close
+        result["ret"] = np.log(result["close"] / result["close"].shift(1))
+        result["ref_ret"] = np.log(ref_close / ref_close.shift(1))
+        result[f"corr_{self.config.prefix}"] = result["ret"].rolling(
+            self.config.corr_window, min_periods=1
+        ).corr(result["ref_ret"])
+        result.drop(columns=["_ref_close", "ret", "ref_ret"], inplace=True)
+        return result
+
+    def get_feature_names(self) -> list[str]:
+        """Return names of generated cross-asset features."""
+        return [f"corr_{self.config.prefix}"]

--- a/src/trading_rl_agent/features/market_microstructure.py
+++ b/src/trading_rl_agent/features/market_microstructure.py
@@ -25,6 +25,14 @@ class MarketMicrostructure:
 
     def add_microstructure_features(self, df: pd.DataFrame) -> pd.DataFrame:
         """Add basic microstructure features to ``df``."""
+        required_columns = ["high", "low", "close", "open", "volume"]
+        missing_columns = [col for col in required_columns if col not in df.columns]
+        if missing_columns:
+            raise ValueError(f"Missing required columns: {missing_columns}")
+
+        if df.empty:
+            return df.copy()
+
         result = df.copy()
         result["hl_spread"] = (
             result["high"].astype(float) - result["low"].astype(float)

--- a/src/trading_rl_agent/features/market_microstructure.py
+++ b/src/trading_rl_agent/features/market_microstructure.py
@@ -1,0 +1,40 @@
+"""Market microstructure feature calculations."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from ..core.logging import get_logger
+
+
+@dataclass
+class MicrostructureConfig:
+    """Configuration for microstructure feature calculations."""
+
+    volume_window: int = 5
+
+
+class MarketMicrostructure:
+    """Compute simple market microstructure features."""
+
+    def __init__(self, config: Optional[MicrostructureConfig] = None) -> None:
+        self.config = config or MicrostructureConfig()
+        self.logger = get_logger(self.__class__.__name__)
+
+    def add_microstructure_features(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Add basic microstructure features to ``df``."""
+        result = df.copy()
+        result["hl_spread"] = (
+            result["high"].astype(float) - result["low"].astype(float)
+        ) / result["close"].replace(0, np.nan)
+        result["close_open_diff"] = result["close"] - result["open"]
+        result["volume_imbalance"] = result["volume"] - result["volume"].rolling(
+            self.config.volume_window, min_periods=1
+        ).mean()
+        return result
+
+    def get_feature_names(self) -> list[str]:
+        """Return names of generated microstructure features."""
+        return ["hl_spread", "close_open_diff", "volume_imbalance"]

--- a/src/trading_rl_agent/features/pipeline.py
+++ b/src/trading_rl_agent/features/pipeline.py
@@ -35,14 +35,13 @@ class FeaturePipeline:
         cross_df: Optional[pd.DataFrame] = None,
         sentiment: Optional[pd.Series] = None,
     ) -> pd.DataFrame:
-        """Apply all feature generators sequentially."""
-        result = df.copy()
-        result = self.technical.calculate_all_indicators(result)
-        result = self.microstructure.add_microstructure_features(result)
+        """Apply all feature generators sequentially. Modifies the input DataFrame in place."""
+        self.technical.calculate_all_indicators(df)
+        self.microstructure.add_microstructure_features(df)
         if cross_df is not None:
-            result = self.cross_asset.add_cross_asset_features(result, cross_df)
-        result = self.alternative.add_alternative_features(result, sentiment)
-        return result
+            self.cross_asset.add_cross_asset_features(df, cross_df)
+        self.alternative.add_alternative_features(df, sentiment)
+        return df
 
     def get_feature_names(self) -> list[str]:
         """Return names of all features that can be generated."""

--- a/src/trading_rl_agent/features/pipeline.py
+++ b/src/trading_rl_agent/features/pipeline.py
@@ -1,0 +1,54 @@
+"""Feature pipeline composing multiple feature generators."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pandas as pd
+
+from ..core.logging import get_logger
+from .alternative_data import AlternativeDataFeatures
+from .cross_asset import CrossAssetFeatures
+from .market_microstructure import MarketMicrostructure
+from .technical_indicators import TechnicalIndicators
+
+
+class FeaturePipeline:
+    """Compose various feature generators into a single pipeline."""
+
+    def __init__(
+        self,
+        technical: Optional[TechnicalIndicators] = None,
+        microstructure: Optional[MarketMicrostructure] = None,
+        cross_asset: Optional[CrossAssetFeatures] = None,
+        alternative: Optional[AlternativeDataFeatures] = None,
+    ) -> None:
+        self.technical = technical or TechnicalIndicators()
+        self.microstructure = microstructure or MarketMicrostructure()
+        self.cross_asset = cross_asset or CrossAssetFeatures()
+        self.alternative = alternative or AlternativeDataFeatures()
+        self.logger = get_logger(self.__class__.__name__)
+
+    def transform(
+        self,
+        df: pd.DataFrame,
+        cross_df: Optional[pd.DataFrame] = None,
+        sentiment: Optional[pd.Series] = None,
+    ) -> pd.DataFrame:
+        """Apply all feature generators sequentially."""
+        result = df.copy()
+        result = self.technical.calculate_all_indicators(result)
+        result = self.microstructure.add_microstructure_features(result)
+        if cross_df is not None:
+            result = self.cross_asset.add_cross_asset_features(result, cross_df)
+        result = self.alternative.add_alternative_features(result, sentiment)
+        return result
+
+    def get_feature_names(self) -> list[str]:
+        """Return names of all features that can be generated."""
+        names: list[str] = []
+        names.extend(self.technical.get_feature_names())
+        names.extend(self.microstructure.get_feature_names())
+        names.extend(self.cross_asset.get_feature_names())
+        names.extend(self.alternative.get_feature_names())
+        return names

--- a/src/trading_rl_agent/features/technical_indicators.py
+++ b/src/trading_rl_agent/features/technical_indicators.py
@@ -128,6 +128,7 @@ class TechnicalIndicators:
             fast=self.config.macd_fast,
             slow=self.config.macd_slow,
             signal=self.config.macd_signal,
+            talib=False,
         )
         df["macd"] = macd_df[
             f"MACD_{self.config.macd_fast}_{self.config.macd_slow}_{self.config.macd_signal}"

--- a/tests/unit/test_feature_pipeline_module.py
+++ b/tests/unit/test_feature_pipeline_module.py
@@ -1,0 +1,92 @@
+import sys
+from pathlib import Path
+import types
+import logging
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+if "structlog" not in sys.modules:
+    stub = types.SimpleNamespace(
+        BoundLogger=object,
+        stdlib=types.SimpleNamespace(
+            ProcessorFormatter=object,
+            BoundLogger=object,
+            LoggerFactory=lambda: None,
+            filter_by_level=lambda *a, **k: None,
+            add_logger_name=lambda *a, **k: None,
+            add_log_level=lambda *a, **k: None,
+            PositionalArgumentsFormatter=lambda: None,
+            wrap_for_formatter=lambda f: f,
+        ),
+        processors=types.SimpleNamespace(
+            TimeStamper=lambda **_: None,
+            StackInfoRenderer=lambda **_: None,
+            format_exc_info=lambda **_: None,
+            UnicodeDecoder=lambda **_: None,
+        ),
+        dev=types.SimpleNamespace(ConsoleRenderer=lambda **_: None),
+        configure=lambda **_: None,
+        get_logger=lambda name=None: logging.getLogger(name),
+    )
+    sys.modules["structlog"] = stub
+
+if "trading_rl_agent" not in sys.modules:
+    pkg = types.ModuleType("trading_rl_agent")
+    pkg.__path__ = [str(Path(__file__).resolve().parents[2] / "src" / "trading_rl_agent")]
+    sys.modules["trading_rl_agent"] = pkg
+
+base = Path(__file__).resolve().parents[2] / "src" / "trading_rl_agent"
+for pkg_name in ["features"]:
+    key = f"trading_rl_agent.{pkg_name}"
+    if key not in sys.modules:
+        mod = types.ModuleType(key)
+        mod.__path__ = [str(base / pkg_name)]
+        sys.modules[key] = mod
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+
+from trading_rl_agent.features.pipeline import FeaturePipeline  # noqa: E402
+
+
+class DummyTechnicalIndicators:
+    def calculate_all_indicators(self, df):
+        df = df.copy()
+        df["dummy"] = 1
+        return df
+
+    def get_feature_names(self):
+        return ["dummy"]
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_feature_pipeline_basic():
+    n = 30
+    df = pd.DataFrame(
+        {
+            "open": np.arange(1, n + 1, dtype=float),
+            "high": np.arange(1, n + 1, dtype=float) + 1,
+            "low": np.arange(1, n + 1, dtype=float) - 1,
+            "close": np.arange(1, n + 1, dtype=float) + 0.5,
+            "volume": np.arange(100, 100 + n, dtype=float),
+        }
+    )
+    ref = pd.DataFrame({"close": np.linspace(10, 10 + n - 1, n)})
+
+    pipeline = FeaturePipeline(technical=DummyTechnicalIndicators())
+    result = pipeline.transform(df, cross_df=ref)
+
+    expected_cols = [
+        "hl_spread",
+        "close_open_diff",
+        "volume_imbalance",
+        f"corr_{pipeline.cross_asset.config.prefix}",
+        pipeline.alternative.config.sentiment_column,
+    ]
+
+    for col in expected_cols:
+        assert col in result.columns
+        assert result[col].notnull().any()


### PR DESCRIPTION
## Summary
- implement MarketMicrostructure, CrossAssetFeatures, AlternativeDataFeatures
- add FeaturePipeline and hook up feature modules
- tweak MACD calculation for pandas-ta compatibility
- test basic FeaturePipeline usage

## Testing
- `flake8 src/trading_rl_agent/features/ tests/unit/test_feature_pipeline_module.py`
- `pytest tests/unit/test_feature_pipeline_module.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686db3447688832e9978e9bfb5be6d01

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced modules for alternative data, cross-asset correlation, and market microstructure feature calculations.
  * Added a unified feature pipeline that combines technical, microstructure, cross-asset, and sentiment-based features into a single transformation.
* **Bug Fixes**
  * Improved technical indicators to explicitly set the backend for MACD calculation.
* **Tests**
  * Added unit tests to verify the feature pipeline produces expected outputs and valid feature columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->