### PR TITLE
Add EnsembleAgent wrapper for compatibility

### DIFF
--- a/src/trading_rl_agent/__init__.py
+++ b/src/trading_rl_agent/__init__.py
@@ -46,6 +46,7 @@ __all__ = [
 _OPTIONAL_IMPORTS = {
     "Trainer": (".agents.trainer", "Trainer"),
     "WeightedEnsembleAgent": (".agents.policy_utils", "WeightedEnsembleAgent"),
+    "EnsembleAgent": (".agents.policy_utils", "EnsembleAgent"),
     "CallablePolicy": (".agents.policy_utils", "CallablePolicy"),
     "weighted_policy_mapping": (".agents.policy_utils", "weighted_policy_mapping"),
     "PortfolioManager": (".portfolio.manager", "PortfolioManager"),

--- a/src/trading_rl_agent/agents/__init__.py
+++ b/src/trading_rl_agent/agents/__init__.py
@@ -7,7 +7,12 @@ from .trainer import Trainer
 from .td3_agent import TD3Agent
 from .sac_agent import SACAgent
 from .rainbow_dqn_agent import RainbowDQNAgent
-from .policy_utils import CallablePolicy, WeightedEnsembleAgent, weighted_policy_mapping
+from .policy_utils import (
+    CallablePolicy,
+    WeightedEnsembleAgent,
+    EnsembleAgent,
+    weighted_policy_mapping,
+)
 
 __all__ = [
     "Trainer",
@@ -16,5 +21,6 @@ __all__ = [
     "RainbowDQNAgent",
     "CallablePolicy",
     "WeightedEnsembleAgent",
+    "EnsembleAgent",
     "weighted_policy_mapping",
 ]

--- a/src/trading_rl_agent/agents/configs.py
+++ b/src/trading_rl_agent/agents/configs.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 
 @dataclass
 class EnsembleConfig:
-    """Configuration options for :class:`EnsembleAgent`."""
+    """Configuration options for :class:`WeightedEnsembleAgent`."""
 
     agents: dict[str, dict[str, Any]] = field(
         default_factory=lambda: {

--- a/src/trading_rl_agent/agents/policy_utils.py
+++ b/src/trading_rl_agent/agents/policy_utils.py
@@ -74,7 +74,4 @@ class WeightedEnsembleAgent:
 
 class EnsembleAgent(WeightedEnsembleAgent):
     """Backward-compatible alias for :class:`WeightedEnsembleAgent`."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
+    pass

--- a/src/trading_rl_agent/agents/policy_utils.py
+++ b/src/trading_rl_agent/agents/policy_utils.py
@@ -70,3 +70,11 @@ class WeightedEnsembleAgent:
         policy_id = self.mapping_fn("agent0")
         action, _, _ = self.policy_map[policy_id].compute_single_action(obs)
         return action
+
+
+class EnsembleAgent(WeightedEnsembleAgent):
+    """Backward-compatible alias for :class:`WeightedEnsembleAgent`."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+


### PR DESCRIPTION
## Summary
- provide `EnsembleAgent` wrapper class for backward compatibility
- export new alias from `agents` package and lazy loader
- reference `WeightedEnsembleAgent` in ensemble config docs

## Testing
- `pytest -q tests/unit/test_policy_utils.py::test_weighted_ensemble_agent`

------
https://chatgpt.com/codex/tasks/task_e_686dbed5e73c832e902ecd2677b242e6