### PR TITLE
Add PPOAgent wrapper

### DIFF
--- a/src/trading_rl_agent/__init__.py
+++ b/src/trading_rl_agent/__init__.py
@@ -51,6 +51,7 @@ _OPTIONAL_IMPORTS = {
     "weighted_policy_mapping": (".agents.policy_utils", "weighted_policy_mapping"),
     "PortfolioManager": (".portfolio.manager", "PortfolioManager"),
     "ExecutionEngine": (".execution", "ExecutionEngine"),
+    "PPOAgent": (".agents.ppo_agent", "PPOAgent"),
 }
 
 

--- a/src/trading_rl_agent/agents/__init__.py
+++ b/src/trading_rl_agent/agents/__init__.py
@@ -6,6 +6,7 @@
 from .trainer import Trainer
 from .td3_agent import TD3Agent
 from .sac_agent import SACAgent
+from .ppo_agent import PPOAgent
 from .rainbow_dqn_agent import RainbowDQNAgent
 from .policy_utils import (
     CallablePolicy,
@@ -18,6 +19,7 @@ __all__ = [
     "Trainer",
     "SACAgent",
     "TD3Agent",
+    "PPOAgent",
     "RainbowDQNAgent",
     "CallablePolicy",
     "WeightedEnsembleAgent",

--- a/src/trading_rl_agent/agents/ppo_agent.py
+++ b/src/trading_rl_agent/agents/ppo_agent.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import gymnasium as gym
+from gymnasium import spaces
+import numpy as np
+from stable_baselines3 import PPO
+
+
+class DummyEnv(gym.Env):
+    """Minimal environment used to initialize SB3 agents."""
+
+    def __init__(self, state_dim: int, action_dim: int):
+        super().__init__()
+        self.observation_space = spaces.Box(
+            low=-np.inf, high=np.inf, shape=(state_dim,), dtype=np.float32
+        )
+        self.action_space = spaces.Box(
+            low=-1.0, high=1.0, shape=(action_dim,), dtype=np.float32
+        )
+
+    def reset(self, *, seed: int | None = None, options=None):
+        return np.zeros(self.observation_space.shape, dtype=np.float32), {}
+
+    def step(self, action):
+        obs = np.zeros(self.observation_space.shape, dtype=np.float32)
+        reward = 0.0
+        terminated = True
+        truncated = False
+        info = {}
+        return obs, reward, terminated, truncated, info
+
+
+class PPOAgent:
+    """Wrapper around :class:`stable_baselines3.PPO`."""
+
+    def __init__(
+        self,
+        state_dim: int,
+        action_dim: int,
+        config: dict | None = None,
+        device: str = "cpu",
+    ):
+        config = config or {}
+        self.state_dim = state_dim
+        self.action_dim = action_dim
+        self.device = device
+
+        env = DummyEnv(state_dim, action_dim)
+        self.model = PPO(
+            "MlpPolicy",
+            env,
+            verbose=0,
+            device=device,
+            learning_rate=config.get("learning_rate", 3e-4),
+            n_steps=config.get("n_steps", 2048),
+            batch_size=config.get("batch_size", 64),
+            gamma=config.get("gamma", 0.99),
+            gae_lambda=config.get("gae_lambda", 0.95),
+        )
+
+    def select_action(self, state: np.ndarray, evaluate: bool = False) -> np.ndarray:
+        return self.model.predict(state, deterministic=evaluate)[0]
+
+    def train(self, total_timesteps: int = 1) -> dict:
+        self.model.learn(total_timesteps=total_timesteps)
+        return {}
+
+    update = train
+
+    def save(self, filepath: str) -> None:
+        self.model.save(filepath)
+
+    def load(self, filepath: str) -> None:
+        self.model = PPO.load(filepath)

--- a/tests/unit/test_ppo_agent.py
+++ b/tests/unit/test_ppo_agent.py
@@ -1,0 +1,71 @@
+"""Unit tests for PPOAgent wrapper."""
+
+import sys
+from pathlib import Path
+import types
+import logging
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+if "structlog" not in sys.modules:
+    stub = types.SimpleNamespace(
+        BoundLogger=object,
+        stdlib=types.SimpleNamespace(
+            ProcessorFormatter=object,
+            BoundLogger=object,
+            LoggerFactory=lambda: None,
+            filter_by_level=lambda *a, **k: None,
+            add_logger_name=lambda *a, **k: None,
+            add_log_level=lambda *a, **k: None,
+            PositionalArgumentsFormatter=lambda: None,
+            wrap_for_formatter=lambda f: f,
+        ),
+        processors=types.SimpleNamespace(
+            TimeStamper=lambda **_: None,
+            StackInfoRenderer=lambda **_: None,
+            format_exc_info=lambda **_: None,
+            UnicodeDecoder=lambda **_: None,
+        ),
+        dev=types.SimpleNamespace(ConsoleRenderer=lambda **_: None),
+        configure=lambda **_: None,
+        get_logger=lambda name=None: logging.getLogger(name),
+    )
+    sys.modules["structlog"] = stub
+
+from trading_rl_agent.agents.ppo_agent import PPOAgent
+
+
+@pytest.mark.unit
+class TestPPOAgent:
+    """Basic tests for PPOAgent."""
+
+    def test_initialization(self):
+        agent = PPOAgent(state_dim=4, action_dim=2)
+        assert agent.state_dim == 4
+        assert agent.action_dim == 2
+        assert hasattr(agent, "model")
+
+    def test_select_action(self):
+        agent = PPOAgent(state_dim=3, action_dim=1)
+        state = np.zeros(3, dtype=np.float32)
+        action = agent.select_action(state)
+        assert action.shape == (1,)
+        action_det = agent.select_action(state, evaluate=True)
+        assert action_det.shape == (1,)
+
+    def test_save_and_load(self):
+        agent = PPOAgent(state_dim=3, action_dim=1)
+        state = np.random.randn(3).astype(np.float32)
+        action_before = agent.select_action(state, evaluate=True)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "ppo_test_model")
+            agent.save(path)
+            new_agent = PPOAgent(state_dim=3, action_dim=1)
+            new_agent.load(path)
+            action_after = new_agent.select_action(state, evaluate=True)
+            np.testing.assert_array_almost_equal(action_before, action_after)


### PR DESCRIPTION
## Summary
- implement PPOAgent based on stable_baselines3
- export PPOAgent through agents package and optional imports
- test PPOAgent initialization, action selection and save/load

## Testing
- `pytest -m unit tests/unit/test_ppo_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_686dc5f5ea28832eb54ba660091b3bf1