### PR TITLE
Add risk-aware training with risk manager

### DIFF
--- a/src/trading_rl_agent/agents/trainer.py
+++ b/src/trading_rl_agent/agents/trainer.py
@@ -5,7 +5,48 @@ import os
 import ray
 from ray import tune
 
-from trading_rl_agent.envs.finrl_trading_env import register_env
+from trading_rl_agent.envs.finrl_trading_env import TradingEnv, register_env
+from risk import RiskfolioConfig, RiskfolioRiskManager
+import gymnasium as gym
+import numpy as np
+
+
+class RiskAwareEnv(gym.Wrapper):
+    """Environment wrapper applying risk management."""
+
+    def __init__(self, env: gym.Env, risk_manager: RiskfolioRiskManager, terminate: bool = True) -> None:
+        super().__init__(env)
+        self.risk_manager = risk_manager
+        self.terminate = terminate
+        self._returns: list[float] = []
+
+    def reset(self, **kwargs):
+        self._returns = []
+        return self.env.reset(**kwargs)
+
+    def step(self, action):
+        # Handle array-like actions
+        act_arr = np.asarray(action)
+        scalar_action = float(act_arr.mean())
+        valid = self.risk_manager.validate_action(scalar_action, self._returns)
+        if not valid:
+            scalar_action = self.risk_manager.risk_adjusted_action(scalar_action, self._returns)
+            act_arr = np.zeros_like(act_arr) + scalar_action
+            if self.terminate:
+                obs, reward, done, truncated, info = self.env.step(act_arr)
+                self._returns.append(float(reward))
+                info = info or {}
+                info["risk_violation"] = True
+                return obs, reward, True, truncated, info
+        obs, reward, done, truncated, info = self.env.step(act_arr)
+        self._returns.append(float(reward))
+        metrics = self.risk_manager.calculate_risk(self._returns)
+        info = info or {}
+        info["risk_metrics"] = metrics
+        if self.terminate and metrics["var"] > self.risk_manager.config.var_limit:
+            info["risk_violation"] = True
+            done = True
+        return obs, reward, done, truncated, info
 
 try:
     from ray.rllib.algorithms.ppo import PPOTrainer
@@ -50,18 +91,46 @@ class Trainer:
         )
         self.ray_config.setdefault("env", "TraderEnv")
         self.ray_config.setdefault("env_config", self.env_cfg)
+
+        risk_cfg = self.trainer_cfg.get("risk_management", {}) if isinstance(self.trainer_cfg, dict) else {}
+        self.risk_enabled = bool(risk_cfg.get("enabled"))
+        if self.risk_enabled:
+            rc = RiskfolioConfig(
+                max_position=risk_cfg.get("max_position", 1.0),
+                min_position=risk_cfg.get("min_position", -1.0),
+                var_limit=risk_cfg.get("var_limit", 0.02),
+                var_alpha=risk_cfg.get("var_alpha", 0.05),
+            )
+            self.risk_manager = RiskfolioRiskManager(rc)
+            self.terminate_on_violation = risk_cfg.get("terminate_on_violation", True)
+        else:
+            self.risk_manager = None
+            self.terminate_on_violation = False
         if not ray.is_initialized():
             if self.ray_address:
                 ray.init(address=self.ray_address)
             else:
                 ray.init()
         register_env()
+        self._register_risk_env()
 
         os.makedirs(self.save_dir, exist_ok=True)
         print(
             f"Initialized Trainer with seed={self.seed}, save_dir='{self.save_dir}', ray_address={self.ray_address}"
         )
 
+    def _register_risk_env(self) -> None:
+        """Register trading environment with optional risk management."""
+
+        from ray.tune.registry import register_env as ray_register_env
+
+        def creator(cfg):
+            env = TradingEnv(cfg)
+            if self.risk_enabled and self.risk_manager is not None:
+                env = RiskAwareEnv(env, self.risk_manager, self.terminate_on_violation)
+            return env
+
+        ray_register_env("TraderEnv", creator)
     def train(self):
         print(
             f"[Trainer] Starting training with configs:\n  env={self.env_cfg}\n  model={self.model_cfg}\n  trainer={self.trainer_cfg}"

--- a/src/trading_rl_agent/agents/trainer.py
+++ b/src/trading_rl_agent/agents/trainer.py
@@ -22,7 +22,7 @@ class RiskAwareEnv(gym.Wrapper):
 
     def reset(self, **kwargs):
         self._returns = []
-        return self.env.reset(**kwargs)
+        return super().reset(**kwargs)
 
     def step(self, action):
         # Handle array-like actions

--- a/tests/integration/test_risk_aware_training.py
+++ b/tests/integration/test_risk_aware_training.py
@@ -1,0 +1,80 @@
+import sys
+from pathlib import Path
+import numpy as np
+import pandas as pd
+from unittest.mock import Mock, patch
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+if "structlog" not in sys.modules:
+    import types
+    import logging
+
+    stub = types.SimpleNamespace(
+        BoundLogger=object,
+        stdlib=types.SimpleNamespace(
+            ProcessorFormatter=object,
+            BoundLogger=object,
+            LoggerFactory=lambda: None,
+            filter_by_level=lambda *a, **k: None,
+            add_logger_name=lambda *a, **k: None,
+            add_log_level=lambda *a, **k: None,
+            PositionalArgumentsFormatter=lambda: None,
+            wrap_for_formatter=lambda f: f,
+        ),
+        processors=types.SimpleNamespace(
+            TimeStamper=lambda **_: None,
+            StackInfoRenderer=lambda **_: None,
+            format_exc_info=lambda **_: None,
+            UnicodeDecoder=lambda **_: None,
+        ),
+        dev=types.SimpleNamespace(ConsoleRenderer=lambda **_: None),
+        configure=lambda **_: None,
+        get_logger=lambda name=None: logging.getLogger(name),
+    )
+    sys.modules["structlog"] = stub
+
+from trading_rl_agent.agents.trainer import Trainer
+
+pytestmark = pytest.mark.integration
+
+def test_risk_aware_training(tmp_path):
+    df = pd.DataFrame({
+        "open": [1.0] * 20,
+        "high": [1.0] * 20,
+        "low": [1.0] * 20,
+        "close": [1.0] * 20,
+        "volume": [1.0] * 20,
+    })
+    csv_path = tmp_path / "data.csv"
+    df.to_csv(csv_path, index=False)
+
+    env_cfg = {"dataset_paths": [str(csv_path)], "window_size": 5}
+    trainer_cfg = {
+        "algorithm": "ppo",
+        "num_iterations": 1,
+        "ray_config": {"env": "TraderEnv"},
+        "risk_management": {"enabled": True, "var_limit": 0.0001},
+    }
+
+    with (
+        patch("ray.init"),
+        patch("ray.is_initialized", return_value=False),
+        patch("ray.shutdown"),
+        patch("ray.tune.registry.register_env") as reg_env,
+        patch("trading_rl_agent.envs.finrl_trading_env.register_env"),
+        patch("trading_rl_agent.agents.trainer.tune.Tuner") as tuner_cls,
+    ):
+        tuner = Mock()
+        tuner.fit.return_value = Mock()
+        tuner_cls.return_value = tuner
+
+        trainer = Trainer(env_cfg, {}, trainer_cfg, save_dir=str(tmp_path))
+        env_creator = reg_env.call_args[0][1]
+        env = env_creator(env_cfg)
+        assert hasattr(env, "risk_manager")
+        trainer.train()
+        assert tuner_cls.called
+        assert tuner.fit.called
+


### PR DESCRIPTION
## Summary
- integrate RiskfolioRiskManager into Trainer
- wrap TradingEnv with RiskAwareEnv to enforce risk limits
- support optional risk management configuration
- test trainer risk integration

## Testing
- `pytest -m integration tests/integration/test_risk_aware_training.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686dca5b259c832ea53202f1c00d540d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a risk management option for training environments, allowing risk-aware trading strategies with configurable risk limits and early episode termination on violations.
  * Added risk metrics and violation flags to environment feedback for enhanced transparency during training.

* **Tests**
  * Added an integration test to validate risk-aware training functionality and ensure correct environment setup when risk management is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->