### PR TITLE
Add sample training script and docs

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -142,6 +142,33 @@ python evaluate_agent.py --config config/production_config.yaml
 python scripts/generate_performance_report.py
 ```
 
+## 🎬 End-to-End Example
+
+Try the quick demo script to see the pieces working together:
+
+```bash
+python scripts/train_sample.py
+```
+
+This command loads a sample dataset (or generates synthetic data), builds a
+`FeaturePipeline`, trains a lightweight `PPOAgent` for a few steps and writes
+two files under `./outputs/`:
+
+- `sample_data.csv` – the processed dataset used for training
+- `ppo_agent_checkpoint.zip` – the saved agent checkpoint
+
+You can evaluate the trained agent using:
+
+```bash
+python evaluate_agent.py \
+    --data outputs/sample_data.csv \
+    --checkpoint outputs/ppo_agent_checkpoint.zip \
+    --agent ppo \
+    --output outputs/eval.json
+```
+
+The evaluation metrics will be saved in `outputs/eval.json`.
+
 ## 🔄 Next Steps
 
 ### Production Deployment

--- a/evaluate_agent.py
+++ b/evaluate_agent.py
@@ -24,7 +24,7 @@ import numpy as np
 from trading_rl_agent.agents.policy_utils import CallablePolicy, WeightedEnsembleAgent
 from trading_rl_agent.agents.sac_agent import SACAgent
 from trading_rl_agent.agents.td3_agent import TD3Agent
-from trading_rl_agent.envs.trading_env import TradingEnv
+from trading_rl_agent.envs.finrl_trading_env import TradingEnv
 from trading_rl_agent.utils import metrics
 
 
@@ -40,7 +40,7 @@ def parse_args() -> argparse.Namespace:
         "--agent",
         type=str,
         default="sac",
-        choices=["sac", "td3", "ensemble"],
+        choices=["sac", "td3", "ppo", "ensemble"],
         help="Type of agent to load",
     )
     parser.add_argument(
@@ -62,6 +62,11 @@ def load_agent(agent_type: str, state_dim: int, action_dim: int, checkpoint: str
         return agent
     if agent_type == "td3":
         agent = TD3Agent(state_dim=state_dim, action_dim=action_dim)
+        agent.load(checkpoint)
+        return agent
+    if agent_type == "ppo":
+        from trading_rl_agent.agents.ppo_agent import PPOAgent
+        agent = PPOAgent(state_dim=state_dim, action_dim=action_dim)
         agent.load(checkpoint)
         return agent
 

--- a/scripts/train_sample.py
+++ b/scripts/train_sample.py
@@ -53,7 +53,7 @@ from trading_rl_agent import PPOAgent
 
 
 OUTPUT_DIR = Path("./outputs")
-OUTPUT_DIR.mkdir(exist_ok=True)
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 DATA_PATH = OUTPUT_DIR / "sample_data.csv"
 CHECKPOINT_PATH = OUTPUT_DIR / "ppo_agent_checkpoint.zip"
 

--- a/scripts/train_sample.py
+++ b/scripts/train_sample.py
@@ -1,0 +1,87 @@
+import sys
+import types
+import logging
+from pathlib import Path
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Optional dependency stubs
+# ---------------------------------------------------------------------------
+if "structlog" not in sys.modules:
+    stub = types.SimpleNamespace(
+        BoundLogger=object,
+        stdlib=types.SimpleNamespace(
+            ProcessorFormatter=object,
+            BoundLogger=object,
+            LoggerFactory=lambda: None,
+            filter_by_level=lambda *a, **k: None,
+            add_logger_name=lambda *a, **k: None,
+            add_log_level=lambda *a, **k: None,
+            PositionalArgumentsFormatter=lambda: None,
+            wrap_for_formatter=lambda f: f,
+        ),
+        processors=types.SimpleNamespace(
+            TimeStamper=lambda **_: None,
+            StackInfoRenderer=lambda **_: None,
+            format_exc_info=lambda **_: None,
+            UnicodeDecoder=lambda **_: None,
+        ),
+        dev=types.SimpleNamespace(ConsoleRenderer=lambda **_: None),
+        configure=lambda **_: None,
+        get_logger=lambda name=None: logging.getLogger(name),
+    )
+    sys.modules["structlog"] = stub
+
+if "nltk.sentiment.vader" not in sys.modules:
+    dummy = types.ModuleType("nltk.sentiment.vader")
+
+    class DummySIA:
+        def polarity_scores(self, text):
+            return {"compound": 0.0}
+
+    dummy.SentimentIntensityAnalyzer = DummySIA
+    sys.modules["nltk.sentiment.vader"] = dummy
+
+# ---------------------------------------------------------------------------
+# Add src to Python path so the package is importable without installation
+# ---------------------------------------------------------------------------
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from trading_rl_agent.data.synthetic import fetch_synthetic_data
+from trading_rl_agent.features import FeaturePipeline
+from trading_rl_agent import PPOAgent
+
+
+OUTPUT_DIR = Path("./outputs")
+OUTPUT_DIR.mkdir(exist_ok=True)
+DATA_PATH = OUTPUT_DIR / "sample_data.csv"
+CHECKPOINT_PATH = OUTPUT_DIR / "ppo_agent_checkpoint.zip"
+
+
+def load_data() -> pd.DataFrame:
+    """Load bundled sample dataset or generate synthetic data."""
+    packaged = Path(__file__).resolve().parents[1] / "data" / "sample_data.csv"
+    if packaged.exists():
+        print(f"Loading bundled dataset from {packaged}")
+        return pd.read_csv(packaged)
+    print("Bundled sample dataset not found, generating synthetic data.")
+    return fetch_synthetic_data(n_samples=120)
+
+
+def main() -> None:
+    df = load_data()
+    pipeline = FeaturePipeline()
+    df = pipeline.transform(df)
+    df = df.select_dtypes(include=["number"]).dropna()
+    df.to_csv(DATA_PATH, index=False)
+    print(f"Prepared data saved to {DATA_PATH}")
+
+    state_dim = df.shape[1]
+    agent = PPOAgent(state_dim=state_dim, action_dim=1)
+    agent.train(total_timesteps=100)
+    agent.save(str(CHECKPOINT_PATH))
+    print(f"Checkpoint saved to {CHECKPOINT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_sample.py
+++ b/scripts/train_sample.py
@@ -7,41 +7,44 @@ import pandas as pd
 # ---------------------------------------------------------------------------
 # Optional dependency stubs
 # ---------------------------------------------------------------------------
-if "structlog" not in sys.modules:
-    stub = types.SimpleNamespace(
-        BoundLogger=object,
-        stdlib=types.SimpleNamespace(
-            ProcessorFormatter=object,
+def stub_optional_dependencies():
+    """Stub optional dependencies to avoid import errors."""
+    if "structlog" not in sys.modules:
+        stub = types.SimpleNamespace(
             BoundLogger=object,
-            LoggerFactory=lambda: None,
-            filter_by_level=lambda *a, **k: None,
-            add_logger_name=lambda *a, **k: None,
-            add_log_level=lambda *a, **k: None,
-            PositionalArgumentsFormatter=lambda: None,
-            wrap_for_formatter=lambda f: f,
-        ),
-        processors=types.SimpleNamespace(
-            TimeStamper=lambda **_: None,
-            StackInfoRenderer=lambda **_: None,
-            format_exc_info=lambda **_: None,
-            UnicodeDecoder=lambda **_: None,
-        ),
-        dev=types.SimpleNamespace(ConsoleRenderer=lambda **_: None),
-        configure=lambda **_: None,
-        get_logger=lambda name=None: logging.getLogger(name),
-    )
-    sys.modules["structlog"] = stub
+            stdlib=types.SimpleNamespace(
+                ProcessorFormatter=object,
+                BoundLogger=object,
+                LoggerFactory=lambda: None,
+                filter_by_level=lambda *a, **k: None,
+                add_logger_name=lambda *a, **k: None,
+                add_log_level=lambda *a, **k: None,
+                PositionalArgumentsFormatter=lambda: None,
+                wrap_for_formatter=lambda f: f,
+            ),
+            processors=types.SimpleNamespace(
+                TimeStamper=lambda **_: None,
+                StackInfoRenderer=lambda **_: None,
+                format_exc_info=lambda **_: None,
+                UnicodeDecoder=lambda **_: None,
+            ),
+            dev=types.SimpleNamespace(ConsoleRenderer=lambda **_: None),
+            configure=lambda **_: None,
+            get_logger=lambda name=None: logging.getLogger(name),
+        )
+        sys.modules["structlog"] = stub
 
-if "nltk.sentiment.vader" not in sys.modules:
-    dummy = types.ModuleType("nltk.sentiment.vader")
+    if "nltk.sentiment.vader" not in sys.modules:
+        dummy = types.ModuleType("nltk.sentiment.vader")
 
-    class DummySIA:
-        def polarity_scores(self, text):
-            return {"compound": 0.0}
+        class DummySIA:
+            def polarity_scores(self, text):
+                return {"compound": 0.0}
 
-    dummy.SentimentIntensityAnalyzer = DummySIA
-    sys.modules["nltk.sentiment.vader"] = dummy
+        dummy.SentimentIntensityAnalyzer = DummySIA
+        sys.modules["nltk.sentiment.vader"] = dummy
 
+stub_optional_dependencies()
 # ---------------------------------------------------------------------------
 # Add src to Python path so the package is importable without installation
 # ---------------------------------------------------------------------------

--- a/scripts/train_sample.py
+++ b/scripts/train_sample.py
@@ -57,14 +57,15 @@ OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 DATA_PATH = OUTPUT_DIR / "sample_data.csv"
 CHECKPOINT_PATH = OUTPUT_DIR / "ppo_agent_checkpoint.zip"
 
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 def load_data() -> pd.DataFrame:
     """Load bundled sample dataset or generate synthetic data."""
     packaged = Path(__file__).resolve().parents[1] / "data" / "sample_data.csv"
     if packaged.exists():
-        print(f"Loading bundled dataset from {packaged}")
+        logging.info(f"Loading bundled dataset from {packaged}")
         return pd.read_csv(packaged)
-    print("Bundled sample dataset not found, generating synthetic data.")
+    logging.info("Bundled sample dataset not found, generating synthetic data.")
     return fetch_synthetic_data(n_samples=120)
 
 


### PR DESCRIPTION
## Summary
- add `train_sample.py` to demonstrate quick training
- support PPO evaluation in `evaluate_agent.py`
- document end-to-end workflow in Getting Started guide

## Testing
- `python -m py_compile scripts/train_sample.py evaluate_agent.py`
- `pytest tests/unit/test_ppo_agent.py::TestPPOAgent::test_save_and_load -q`

------
https://chatgpt.com/codex/tasks/task_e_686ddb81ae60832eaf6bf68146dc76f2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end example in the documentation demonstrating data preparation, training, and evaluation of a PPO agent.
  * Introduced a new script for training a PPO agent on sample data, producing a processed dataset and checkpoint files.
  * Enabled evaluation of PPO agents alongside existing agent types.

* **Documentation**
  * Expanded getting started guide with a runnable demo workflow and step-by-step instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->