### PR TITLE
Add docs build and linkcheck to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest pytest-cov flake8
         pip install -e .
+    - name: Build documentation
+      run: make -C docs html
+    - name: Link check documentation
+      run: make -C docs linkcheck
     - name: Install pre-commit
       run: pip install pre-commit
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -567,6 +567,15 @@ python -m http.server 8000 --directory _build/html
 make clean
 ```
 
+Continuous integration builds and link checks the documentation using:
+
+```bash
+make -C docs html
+make -C docs linkcheck
+```
+
+Ensure these commands succeed locally before opening a pull request.
+
 ### Documentation Guidelines
 
 - Use clear, concise language


### PR DESCRIPTION
## Summary
- build the documentation in CI
- run linkcheck as part of the workflow
- mention doc build step in CONTRIBUTING guidelines

## Testing
- `pre-commit run --files .github/workflows/ci.yml CONTRIBUTING.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog')*

------
https://chatgpt.com/codex/tasks/task_e_686e99cccb70832eae8f1364d47cf1ad