### PR TITLE
Add standalone disclaimer page and fix links

### DIFF
--- a/CLEANUP_PLAN.md
+++ b/CLEANUP_PLAN.md
@@ -278,3 +278,7 @@ This comprehensive plan builds upon our proven hybrid CNN+LSTM + RL foundation t
 - **Storage**: Optimized with organized experiment outputs
 
 **Repository is now Phase 3 ready with zero technical debt and a solid foundation for multi-asset portfolio development.**
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).

--- a/COMPREHENSIVE_TESTING_FRAMEWORK.md
+++ b/COMPREHENSIVE_TESTING_FRAMEWORK.md
@@ -669,3 +669,7 @@ This comprehensive testing framework provides robust validation for the trading 
 - **Developer Tools**: Flexible test runner and debugging support
 
 The framework ensures code quality, reliability, and maintainability while supporting rapid development and deployment of trading RL agents.
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -501,3 +501,7 @@ sed -i 's/from src\./from trading_rl_agent\./g' tests/**/*.py
 **💡 Pro Tip**: Start with paper trading when testing the new features. The production-grade architecture includes comprehensive safety mechanisms, but it's always best to validate thoroughly before using real capital.
 
 **🚀 Ready to migrate to production-grade trading systems!**
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).

--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ This project is licensed under the MIT License. See [LICENSE](LICENSE) for detai
 
 ---
 
+<a id="disclaimer"></a>
 ## ⚠️ **Disclaimer**
 
 **For educational and research purposes only.** This system is designed for algorithmic trading research and development. Always:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -178,3 +178,7 @@ All core functionality working - environment testing framework complete!
 ---
 
 **🔄 Phase 2 Nearly Complete** | **🧪 495+ Tests Framework** | **📊 Production Dataset Ready**
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).

--- a/docs/ADVANCED_DATASET_DOCUMENTATION.md
+++ b/docs/ADVANCED_DATASET_DOCUMENTATION.md
@@ -343,3 +343,7 @@ print(results["best_config"])
 The `custom_search_space` and `ray_resources_per_trial` parameters let you
 override default hyperparameters and specify CPU/GPU allocation for each Ray
 trial.
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -280,3 +280,7 @@ This hybrid architecture successfully demonstrates how supervised learning can e
   - Can ensemble any number of RLlib-compatible policies.
 
 The agents consume observations from `TradingEnv`, take actions, and optionally contribute to ensemble decisions. This modular setup makes it straightforward to swap out or update individual components while keeping the overall pipeline intact.
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -127,3 +127,7 @@ The following tasks are tracked from the codebase TODOs:
 
 - [x] Migrate training scripts into `src/training` and integrate Ray Tune sweeps.
 - [ ] Provide sentiment and risk scoring APIs in `src/nlp`.
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).

--- a/docs/EVALUATION_GUIDE.md
+++ b/docs/EVALUATION_GUIDE.md
@@ -272,3 +272,7 @@ debug_results = debugger.evaluate_with_diagnostics(
 See [`evaluation_example.ipynb`](../evaluation_example.ipynb) for a brief
 walkthrough of running the evaluation script inside a Jupyter notebook and
 visualizing the resulting metrics.
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).

--- a/docs/PRE_COMMIT_SETUP.md
+++ b/docs/PRE_COMMIT_SETUP.md
@@ -107,3 +107,7 @@ The following hooks are configured and **all passing**:
 - Security vulnerabilities are detected but don't block commits (manual hook)
 - All notebook outputs are automatically cleared to avoid large diffs
 - The setup allows the team to gradually improve code quality without blocking development
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).

--- a/docs/RAY_RLLIB_MIGRATION.md
+++ b/docs/RAY_RLLIB_MIGRATION.md
@@ -146,3 +146,7 @@ agent = TD3Agent(config, state_dim=10, action_dim=3)
 ---
 
 **Note**: This migration ensures compatibility with Ray 2.38.0+ while maintaining all the continuous control capabilities needed for trading applications.
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,10 @@
 
 This directory contains the Sphinx documentation sources for the Trading RL Agent project.
 
-For setup instructions and the Important Disclaimer, see the [project README](../README.md) in the repository root.
+For setup instructions and the Important Disclaimer, see the [project README](../README.md#disclaimer) in the repository root.
 
 Start with [getting_started.md](getting_started.md) or browse the sections in the documentation index.
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -217,3 +217,7 @@ This project relies on PyTorch's built-in dynamic quantization utilities.
    :undoc-members:
    :show-inheritance:
 ```
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).

--- a/docs/disclaimer.md
+++ b/docs/disclaimer.md
@@ -1,0 +1,11 @@
+# Project Disclaimer
+
+This project is provided **for educational and research purposes only**.
+It is designed for algorithmic trading research and development. Always:
+
+- 📊 **Paper trade first**: Test strategies thoroughly before using real capital
+- 🧠 **Understand the risks**: Trading involves substantial risk of loss
+- 👨‍💼 **Consult professionals**: Seek professional advice before deploying capital
+- ⚖️ **Follow regulations**: Ensure compliance with relevant financial regulations
+
+The same text can be found in the [main project README](../README.md#disclaimer).

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -387,3 +387,7 @@ opt_config = OptimizationConfig(
     checkpoint_frequency=10
 )
 ```
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -198,3 +198,7 @@ The evaluation metrics will be saved in `outputs/eval.json`.
 - **Issues**: GitHub issue tracker for bug reports and feature requests
 
 **Current Achievement**: ~733 tests defined with sample data. Larger datasets are optional. Automated quality checks ensure consistency. Metrics are illustrative ✨
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,3 +78,7 @@ portfolio.start_live_trading(agent)
 - ✅ **Ray RLlib 2.38.0+** compatibility (SAC with **FinRL** integration; custom TD3 retained for experimentation)
 - ✅ **Automated quality checks** integrated
   _Metrics are illustrative and rely on sample data._
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -11,3 +11,7 @@ The synthetic data generation and feature engineering pipeline completes in **un
 A single PPO training iteration using the mocked trainer completes in **under 3 ms**.
 
 These numbers come from the `pytest-benchmark` results in `tests/integration/test_end_to_end_pipeline.py`.
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).

--- a/docs/scripts_readme.md
+++ b/docs/scripts_readme.md
@@ -3,3 +3,7 @@
 ```{mdinclude} ../scripts/README.md
 :parser: markdown
 ```
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).

--- a/docs/tests_readme.md
+++ b/docs/tests_readme.md
@@ -3,3 +3,7 @@
 ```{mdinclude} ../tests/README.md
 :parser: markdown
 ```
+
+--
+
+For legal and safety notes see the [project disclaimer](disclaimer.md).


### PR DESCRIPTION
## Summary
- add docs/disclaimer.md with the full legal disclaimer
- link to the new disclaimer from docs/index and all major guides
- update docs/README link to the disclaimer section
- add anchor for the disclaimer in README
- verify links with `make -C docs linkcheck`

## Testing
- `pip install sphinx myst-parser sphinx-autodoc-typehints sphinx_rtd_theme linkify-it-py`
- `make -C docs linkcheck`

------
https://chatgpt.com/codex/tasks/task_e_686e9d6fe478832ebde5e3e003bee5eb