### PR TITLE
Align metrics output with test

### DIFF
--- a/test_output.py
+++ b/test_output.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import sys
+import io
+from unittest.mock import patch
+
+# Add the src directory to the path
+sys.path.insert(0, 'src')
+
+# Import the console module directly
+sys.path.insert(0, 'src/trading_rl_agent')
+from console import print_metrics_table
+
+# Test data
+results = [
+    {
+        "strategy": "momentum",
+        "total_return": 0.15,
+        "sharpe_ratio": 1.25
+    }
+]
+
+print("Testing print_metrics_table with single result:")
+print("=" * 50)
+
+with patch('sys.stdout', new=io.StringIO()) as fake_out:
+    print_metrics_table(results)
+    output = fake_out.getvalue()
+    print("Actual output:")
+    print(repr(output))
+    print("\nFormatted output:")
+    print(output)

--- a/test_output.py
+++ b/test_output.py
@@ -4,8 +4,6 @@ import sys
 import io
 from unittest.mock import patch
 
-# Add the src directory to the path
-sys.path.insert(0, 'src')
 
 # Import the console module directly
 sys.path.insert(0, 'src/trading_rl_agent')


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `test_output.py` to inspect the actual output format of `print_metrics_table` for single results.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `tests/unit/test_console.py` expects a simple 'key: value' output for single results from `print_metrics_table`, but the function appears to produce a rich-formatted table. This script helps visualize the actual output to aid in debugging the discrepancy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new script to test and display the output of the metrics table for trading strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->